### PR TITLE
feat: add MultiCam Suite 2.1 support and expand Companion integration

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,4 @@ nodeLinker: node-modules
 enableScripts: false
 npmMinimalAgeGate: 3d
 npmPreapprovedPackages:
-  - "@companion-module/*"
+  - '@companion-module/*'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # companion-module-multicamsystems-multicamsuite
 
-See [HELP.md](./HELP.md) and [LICENSE](./LICENSE)
+See [HELP.md](./companion/HELP.md) and [LICENSE](./LICENSE)

--- a/build-config.cjs
+++ b/build-config.cjs
@@ -1,7 +1,3 @@
 module.exports = {
-	externals: [
-		{
-			'@microsoft/signalr': 'commonjs @microsoft/signalr',
-		},
-	],
+	externals: ['@microsoft/signalr'],
 }

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -16,93 +16,136 @@ This module will communicate with Multicam Systems' Multicam Suite software.
 
 ## Actions
 
+Deprecated API groups are intentionally excluded.
+
 ### Application
 
-- Application - Start
-- Application - Start with Room
-- Application - Set Auto Mode
-- Application - Toggle Auto/Manual Mode
-- Application - Manually Refresh Data
+- Start, start with template, and start with room
+- Retry a failed start
+- Set or toggle Auto/Manual mode
+- Manually refresh all API data
+
+### Audio
+
+- Select an audio mixer profile discovered from the API
+
+### Camera
+
+- Reset one or all cameras
+- Toggle, enable, or disable automatic framing
 
 ### Composer
 
-- Composer - Select File
-- Composer - Select Composition
-- Composer - Change Element Source
+- Select a Composer file or composition, or untake the current composition
+- Change a composition element source
+
+### Conf
+
+- Set a manual microphone, wide shot, or automatic microphone mode
+- Set AI dynamism and Auto Frame Flow
+- Select a preset bank
+- Enable, disable, or reset automatic titling
+
+### Insitu
+
+- Activate or deactivate tags
+- Activate layouts
+- Recall PTZ presets
+- Start or stop a live extract
 
 ### Medialist
 
-- Medialist - Create
-- Medialist - Select
-- Medialist - Add Media
-- Medialist - Play
-- Medialist - Stop
-- Medialist - Pause
-- Medialist - Move to Index (Selected)
+- Create and select Medialists
+- Add media by path or by full media-description JSON
+- Play, stop, and pause the selected or a specified Medialist
+- Select, play, update, or delete media by API-provided ID
+- Set audio mode and after-play behavior
+- Move media up, down, to an index, or between indexes
+- Clear a Medialist
+
+### Pilot
+
+- Prepare, play, or stop an active-bank sequence
+- Stop the running sequence for a camera
 
 ### Publisher
 
-- Publisher - Publish Recording
+- Publish a recording with a fully automated workflow
+- Rename or delete a recording
+- Remove unavailable recording entries
+
+### Radio
+
+- Set a manual microphone, wide shot, or automatic microphone mode
+- Set AI dynamism and Auto Frame Flow overrides
+- Select a preset bank
+- Enable, disable, or reset automatic titling
+- Enable/disable automation and override the current program
+- Merge, replace, or clear automation variables using JSON
 
 ### Recording
 
-- Recording - Start
-- Recording - Start (Duration)
-- Recording - Pause/Resume
-- Recording - Stop
-- Recording - Start All ISO Recordings
-- Recording - Stop All ISO Recordings
-- Recording - Start ISO Recording
-- Recording - Stop ISO Recording
+- Start, timed start, Tracking start, pause/resume, and stop
+- Set recording split duration
+- Start or stop a live extract
+- Start or stop all ISO recordings or a recording on one source
 
 ### Scenes
 
-- Scenes - Select Scene File
-- Scenes - Take Scene
+- Select a Scene file and take a Scene
 
 ### Streaming
 
-- Streaming – Select Catalog
-- Streaming – Start Profile
-- Streaming – Stop Profile
-- Streaming – Start All Profiles in Selected Catalog
-- Streaming – Stop All Profiles in Selected Catalog
+- Select a catalog
+- Start or stop one profile or all profiles
+- Update a profile; the module gets and merges its current model before sending the PUT request
 
-### System
+### Studio
 
-- System - Shutdown
+- Recall a PTZ preset, optionally allowing recall on a live camera
+- Recall a preset and set the camera live
+- Store a preset and run auto framing
 
 ### Titler
 
-- Titler - Set Titler File
-- Titler - Take Element Live
-- Titler - Set Speaker Row Live
-- Titler - Set Panel Row Live
-- Titler - Clear Speaker Live Row
-- Titler - Clear Panel Live Row
-- Titler - Update Speaker Row
-- Titler - Update Panel Row
-- Titler - Delete Speaker Row
-- Titler - Delete Panel Row
-- Titler - Clear Speaker Entry (Live)
-- Titler - Clear Panel Entry (Live)
-- Titler - Add Speaker Entry
-- Titler - Update All Speaker Entries
-- Titler - Add Panel Entry
-- Titler - Update All Panel Entries
-- Titler - Set Ticker Content
+- Select a Titler file and take an element on or off
+- Set or clear live Speaker/Panel rows
+- Add, update, delete, or replace all Speaker/Panel rows
+- Set social-media data and Ticker content
+- Row updates get the current row before merging and sending a complete PUT model
 
 ### Video
 
-- Video - Change Live Source
-- Video - Restart Output
+- Change the live source using the fixed `Source 1`–`Source 40`, `PC Input`, or `Medialist` choices
+- Restart the output
+
+## SignalR state synchronization
+
+- Connect automatically to `/signalr`, including API-key authentication and automatic reconnection
+- Receive real-time events, read current hub state, and refresh dependent API data when needed
+- SignalR is used only for state synchronization and is not exposed as a Companion command action
+
+## Presets
+
+- Ready-made buttons are organized by feature for the most common controls
+- Presets based on API resources are refreshed when applications, profiles, files, scenes, Medialists, or Titler rows change
+- Selection presets pair their action with the matching feedback whenever an observable state is available
+- Video source presets select `Source 1`–`Source 40`, `PC Input`, or `Medialist` and turn red while that same source is live
 
 ## Feedbacks
 
 ### Composer
 
 - Composer - File is currently selected file
-- Composer - Compostion is in currently selected comnposition
+- Composer - Composition is the currently selected composition
+
+### Application / Audio / Conf / Insitu / Medialist / Radio
+
+- Application Auto/Manual mode
+- Selected audio profile
+- Conf and Radio automation mode
+- Active Insitu tag and layout
+- Selected Medialist
 
 ### Scene
 
@@ -116,22 +159,21 @@ This module will communicate with Multicam Systems' Multicam Suite software.
 - Titler - Element's selected speaker row is live
 - Titler - Element's selected panel row is live
 
+### Recording / Streaming / Video
+
+- Recording active and paused
+- Streaming profile active
+- Video source live
+
+### SignalR
+
+- AssistHub connection active
+
 ## Variables
 
-- Computer Name
-- Multicam Name
-- Licensed Applications
-- Application Version
-- Running Application
-- Application Auto/Manual State
-- Application Snapshot
-- Composer - Selected File Name
-- Comnposer - Selected File ID
-- Composer - Selected Composition Name
-- Composer - Selected Composition ID
-- Scene - Selected File Name
-- Scene - Selected File ID
-- Scene - Selected Scene Name
-- Scene - Selected Scene ID
-- Titler - Selected File Name
-- Titler - Selected File ID
+Variables expose the polled and real-time state for Application, Audio, Conf, Insitu, Composer, Medialist, Publisher,
+Radio, Recording, Scenes, Streaming, Titler, Video, and media constraints. SignalR variables expose the connection state,
+last event and payload, record time, Publisher jobs, microphone and zoom state, crop zones, automation notifications,
+social-media messages, live-source changes, piloted devices, and the Assist viewed scene. JSON variables are provided for
+complex API models such as application templates, radio automation variables, Titler element structures, and media
+constraints.

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "../node_modules/@companion-module/base/assets/manifest.schema.json",
+	"type": "connection",
 	"id": "multicamsystems-multicamsuite",
 	"name": "multicamsystems-multicamsuite",
 	"shortname": "mcs",
@@ -15,6 +17,10 @@
 		{
 			"name": "Bryce Seifert",
 			"email": "bryce@bitfocus.io"
+		},
+		{
+			"name": "Vincent Berry",
+			"email": "vincentberry@outlook.fr"
 		}
 	],
 	"legacyIds": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "multicamsystems-multicamsuite",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "multicamsystems-multicamsuite",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {
@@ -22,16 +22,17 @@
 		"yarn": "^4"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.12.0",
+		"@companion-module/base": "2.1.2",
 		"@microsoft/signalr": "^10.0.0"
 	},
 	"devDependencies": {
-		"@companion-module/tools": "^2.7.2",
+		"@companion-module/tools": "3.0.1",
 		"@types/node": "^22.19.18",
 		"eslint": "^9.39.4",
 		"prettier": "^3.8.3",
 		"rimraf": "^6.1.3",
-		"typescript": "~5.5.4"
+		"typescript": "~6.0.3",
+		"typescript-eslint": "^8.56.0"
 	},
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"packageManager": "yarn@4.12.0"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -472,21 +472,6 @@ export function UpdateActions(self: MulticamInstance): void {
 		self.log('error', `${label} is invalid. Refresh the module data and select it again.`)
 	}
 
-	function normalizeAutomationVariables(value: unknown): { Variables: { Key: string; Value: string }[] } | null {
-		if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
-		const record = value as Record<string, unknown>
-		if (Array.isArray(record.Variables)) {
-			const variables = record.Variables.filter(
-				(item): item is { Key: string; Value: string } =>
-					typeof item === 'object' && item !== null && typeof item.Key === 'string' && typeof item.Value === 'string',
-			)
-			return { Variables: variables }
-		}
-		return {
-			Variables: Object.entries(record).map(([Key, item]) => ({ Key, Value: valueToString(item) })),
-		}
-	}
-
 	// APPLICATION
 	actions.applicationStart = {
 		name: 'APPLICATION | Start',
@@ -1094,41 +1079,6 @@ export function UpdateActions(self: MulticamInstance): void {
 					enabled: Boolean(action.options.override),
 				})}`,
 			),
-	}
-
-	actions.radioSetAutomationVariables = {
-		name: 'RADIO | Set Automation Variables',
-		description: 'Updates automation variables. Accepts either an object or the documented Variables payload.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Update Mode',
-				id: 'mode',
-				default: 'PUT',
-				choices: [
-					{ id: 'PUT', label: 'Merge (keep undeclared variables)' },
-					{ id: 'POST', label: 'Replace (clear undeclared variables)' },
-				],
-			},
-			{
-				type: 'textinput',
-				label: 'Variables JSON',
-				id: 'variables',
-				default: '{"Example":"Value"}',
-				useVariables: true,
-				tooltip: 'Either {"Key":"Value"} or {"Variables":[{"Key":"Key","Value":"Value"}]}',
-			},
-		],
-		callback: async (action) => {
-			const parsed = await parseJsonOption<unknown>(self, action.options.variables, 'Automation variables')
-			if (parsed === undefined) return
-			const payload = normalizeAutomationVariables(parsed)
-			if (!payload) {
-				self.log('error', 'Automation variables JSON must be an object')
-				return
-			}
-			await sendAndRefresh(self, '/api/v2/radio/automation/variables', valueToString(action.options.mode), payload)
-		},
 	}
 
 	actions.radioClearAutomationVariables = {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,109 +1,114 @@
-import { CompanionActionDefinitions } from '@companion-module/base'
+import type {
+	CompanionActionDefinitions,
+	CompanionActionSchemaWithoutResult,
+	CompanionOptionValues,
+	SomeCompanionActionInputField,
+} from '@companion-module/base'
 
 import type { MulticamInstance } from './main.js'
 
 import { SendCommand } from './api.js'
-import { runPollCycle, parseMedialistMediaGlobalChoiceId } from './polling.js'
+import { runPollCycle, runPollScopes, parseMedialistMediaGlobalChoiceId } from './polling.js'
+
+export type ActionsSchema = Record<string, CompanionActionSchemaWithoutResult<CompanionOptionValues>>
+
+function valueToString(value: unknown): string {
+	if (value === null || value === undefined) return ''
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return `${value}`
+	try {
+		return JSON.stringify(value) ?? ''
+	} catch (_error) {
+		return ''
+	}
+}
+
+function encodePathPart(value: unknown): string {
+	return encodeURIComponent(valueToString(value))
+}
+
+const RECORDING_AUX_NON_CAMERA_SOURCES = [
+	'Unknown',
+	'VGA',
+	'AUDIO1',
+	'AUDIO2',
+	'AUDIO3',
+	'AUDIO4',
+	'AUDIO5',
+	'AUDIO6',
+	'AUDIO7',
+	'AUDIO8',
+	'Playlist',
+	'Output',
+	'Composition',
+	'File',
+	'WebRTC',
+] as const
+
+function normalizeRecordingAuxSource(value: unknown): string | null {
+	const source = valueToString(value).trim()
+	const cameraMatch = /^(?:Source\s*|CAM)(\d+)$/i.exec(source)
+	if (cameraMatch) {
+		const cameraNumber = Number(cameraMatch[1])
+		return Number.isInteger(cameraNumber) && cameraNumber >= 1 && cameraNumber <= 40 ? `CAM${cameraNumber}` : null
+	}
+
+	return RECORDING_AUX_NON_CAMERA_SOURCES.find((candidate) => candidate.toLowerCase() === source.toLowerCase()) ?? null
+}
+
+function parseCompositeChoiceId(value: unknown, expectedParts: number): string[] | null {
+	try {
+		const parsed = JSON.parse(valueToString(value))
+		if (!Array.isArray(parsed) || parsed.length !== expectedParts || parsed.some((part) => typeof part !== 'string')) {
+			return null
+		}
+		return parsed
+	} catch (_error) {
+		return null
+	}
+}
+
+async function expandOption(_self: MulticamInstance, value: unknown): Promise<string> {
+	return valueToString(value)
+}
+
+async function parseJsonOption<T>(self: MulticamInstance, value: unknown, label: string): Promise<T | undefined> {
+	const expanded = await expandOption(self, value)
+	try {
+		return JSON.parse(expanded) as T
+	} catch (error: any) {
+		self.log('error', `${label} is not valid JSON: ${error?.message ?? error}`)
+		return undefined
+	}
+}
+
+function buildQuery(params: Record<string, unknown>): string {
+	const query = new URLSearchParams()
+	for (const [key, value] of Object.entries(params)) {
+		if (value !== undefined && value !== null && value !== '') {
+			query.set(key, valueToString(value))
+		}
+	}
+	const result = query.toString()
+	return result ? `?${result}` : ''
+}
+
+async function sendAndRefresh(
+	self: MulticamInstance,
+	endpoint: string,
+	method: string = 'POST',
+	payload: unknown = undefined,
+	refresh: boolean = true,
+): Promise<any> {
+	const result = await SendCommand(self, endpoint, method, payload)
+	if (refresh) void runPollCycle(self)
+	return result
+}
 
 export function UpdateActions(self: MulticamInstance): void {
-	const actions: CompanionActionDefinitions = {}
+	const actions: CompanionActionDefinitions<ActionsSchema> = {}
 
 	//APPLICATION
-	actions.applicationStart = {
-		name: 'APPLICATION | Start',
-		description: 'Starts an application.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Application Name',
-				id: 'applicationName',
-				default: self.CHOICES_APPLICATIONS[0].id,
-				choices: self.CHOICES_APPLICATIONS,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/application/start?applicationName=${action.options.applicationName}`, 'POST')
-		},
-	}
-
-	/*actions.applicationStartWithTemplate = {
-		name: 'APPLICATION | Start with Template',
-		description: 'Starts an application with a specified template.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Application Name',
-				id: 'applicationName',
-				default: self.CHOICES_APPLICATIONS[0].id,
-				choices: self.CHOICES_APPLICATIONS,
-			},
-			{
-				type: 'textinput',
-				label: 'Template Name',
-				id: 'templateName',
-				default: '',
-				required: true,
-			},
-			{
-				type: 'checkbox',
-				label: 'Wait for initialization to complete',
-				id: 'waitEndOfInit',
-				default: false,
-			},
-		],
-		callback: async (action) => {
-			const { applicationName, templateName, waitEndOfInit } = action.options
-			await SendCommand(
-				self,
-				`/api/application/startWithTemplate/${applicationName}/${templateName}?waitEndOfInit=${waitEndOfInit}`, 'POST'
-			)
-		},
-	}*/
-
-	actions.applicationStartWithRoom = {
-		name: 'APPLICATION | Start with Room',
-		description: 'Starts an application with a specified room.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Application Name',
-				id: 'applicationName',
-				default: 'Studio',
-				required: true,
-			},
-			{
-				type: 'dropdown',
-				label: 'Room',
-				id: 'roomId',
-				default: self.CHOICES_ROOMS[0]?.id || '',
-				choices: self.CHOICES_ROOMS,
-			},
-			{
-				type: 'checkbox',
-				label: 'Wait for initialization to complete',
-				id: 'waitEndOfInit',
-				default: false,
-			},
-		],
-		callback: async (action) => {
-			const { applicationName, roomId, waitEndOfInit } = action.options
-			await SendCommand(
-				self,
-				`/api/application/startWithRoom/${applicationName}/${roomId}?waitEndOfInit=${waitEndOfInit}`,
-				'POST',
-			)
-		},
-	}
-
-	/*actions.applicationRetryFailedStart = {
-		name: 'APPLICATION | Retry Failed Start',
-		description: 'Retry an application which has failed to start.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/application/retryFailedStart`)
-		},
-	}*/
-
 	actions.applicationSetAutoMode = {
 		name: 'APPLICATION | Set Auto Mode',
 		description: 'Sets the auto/manual state of the application.',
@@ -120,7 +125,7 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/application/auto?isAutoMode=${action.options.isAutoMode}`, 'POST')
+			await SendCommand(self, `/api/application/auto?isAutoMode=${valueToString(action.options.isAutoMode)}`, 'POST')
 		},
 	}
 
@@ -132,51 +137,6 @@ export function UpdateActions(self: MulticamInstance): void {
 			await SendCommand(self, `/api/application/auto/toggle`, 'POST')
 		},
 	}
-
-	/*
-	//AUDIO
-	actions.audioSelectProfile = {
-		name: 'Audio - Select Audio Mixer Profile',
-		description: 'Select audio mixer profile',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Profile Name',
-				id: 'profileName',
-				default: self.CHOICES_AUDIO_PROFILES[0].id,
-				choices: self.CHOICES_AUDIO_PROFILES,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v1/audio/profiles/selected?profileName=${action.options.profileName}`)
-		},
-	}
-
-	//CAMERA
-	actions.cameraResetAll = {
-		name: 'Camera - Reset All',
-		description: 'Performs a "reset" operation on all cameras.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, '/api/v1/camera/reset/all')
-		},
-	}
-
-	actions.cameraReset = {
-		name: 'Camera - Reset Camera',
-		description: 'Reset the specified camera.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Camera ID (e.g. CAM1)',
-				id: 'camId',
-				default: 'CAM1',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v1/camera/reset/${action.options.camId}`)
-		},
-	}*/
 
 	//COMPOSER
 	actions.composerSelectFile = {
@@ -192,7 +152,7 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v3/composer/selected/${action.options.composerFileId}`, 'POST')
+			await SendCommand(self, `/api/v3/composer/selected/${valueToString(action.options.composerFileId)}`, 'POST')
 		},
 	}
 
@@ -209,7 +169,11 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v3/composer/selected/compositions/selected/${action.options.compositionId}`, 'POST')
+			await SendCommand(
+				self,
+				`/api/v3/composer/selected/compositions/selected/${valueToString(action.options.compositionId)}`,
+				'POST',
+			)
 		},
 	}
 
@@ -226,16 +190,19 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 			{
 				type: 'dropdown',
-				label: 'Mixer Video Source (e.g. CAM1)',
+				label: 'Source',
 				id: 'mixerVideoSource',
 				default: 'CAM1',
-				choices: self.CHOICES_VIDEO_SOURCES,
+				choices: self.CHOICES_CAMERA_SOURCES.map((choice) => {
+					const cameraNumber = /^CAM(\d+)$/.exec(String(choice.id))?.[1]
+					return { id: choice.id, label: cameraNumber ? `Source ${cameraNumber}` : choice.label }
+				}),
 			},
 		],
 		callback: async (action) => {
 			const id = action.options.compositionElementId as string
 			const [compositionId, elementId] = id.split('_')
-			const mixerVideoSource = action.options.mixerVideoSource as string
+			const mixerVideoSource = encodeURIComponent(valueToString(action.options.mixerVideoSource))
 			await SendCommand(
 				self,
 				`/api/v3/composer/selected/compositions/selected/${compositionId}/${elementId}/${mixerVideoSource}`,
@@ -243,198 +210,6 @@ export function UpdateActions(self: MulticamInstance): void {
 			)
 		},
 	}
-
-	/*
-	//CONF
-	actions.confSetMicrophoneManual = {
-		name: 'Conf - Set Microphone Manual',
-		description: 'Sets manual mode and forces the active microphone.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Microphone ID',
-				id: 'mic',
-				default: 'MIC1',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/conf/microphones/man/${action.options.mic}`)
-		},
-	}
-
-	actions.confSetMicrophoneWide = {
-		name: 'Conf - Set Wide Shot',
-		description: 'Forces wide shot in manual mode.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/conf/microphones/man/wide`)
-		},
-	}
-
-	actions.confSetMicrophonesAuto = {
-		name: 'Conf - Set Auto Mode',
-		description: 'Sets microphone mode to automatic.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/conf/microphones/auto`)
-		},
-	}
-
-	actions.confSetDynamism = {
-		name: 'Conf - Set Dynamism Level',
-		description: 'Sets the AI dynamism from 0 to 10.',
-		options: [
-			{
-				type: 'number',
-				label: 'Score (0–10)',
-				id: 'score',
-				default: 5,
-				min: 0,
-				max: 10,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/conf/dynamism?score=${action.options.score}`, 'POST')
-		},
-	}
-
-	actions.confEnableAutoFrameFlow = {
-		name: 'Conf - Enable Auto Frame Flow',
-		description: 'Defines if AI should auto frame before setting a solo preset live.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/conf/autoFrameFlow/enable`, 'POST')
-		},
-	}
-
-	actions.confSetCurrentPresetBank = {
-		name: 'Conf - Set Current Preset Bank',
-		description: 'Sets the current preset bank.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Bank ID',
-				id: 'bankId',
-				default: '1',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/conf/presetsbanks/current/${action.options.bankId}`, 'POST')
-		},
-	}
-
-	actions.confSetAutotitlingState = {
-		name: 'Conf - Set Autotitling State',
-		description: 'Toggles the state of automatic titling.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/conf/autotitling`, 'POST')
-		},
-	}
-
-	actions.confResetAutotitling = {
-		name: 'Conf - Reset Autotitling',
-		description: 'Resets the automatic titling configuration.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/conf/autotitling/reset`, 'POST')
-		},
-	}
-
-	//INSITU
-	actions.insituTagOn = {
-		name: 'Insitu - Activate Tag',
-		description: 'Activate the specified Insitu tag ("marker" is a synonym due to old days).',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Tag Name',
-				id: 'tag',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/insitu/tag/on?markerName=${action.options.tag}`, 'POST')
-		},
-	}
-
-	actions.insituTagOff = {
-		name: 'Insitu - Deactivate Tag',
-		description: 'Deactivate the specified Insitu tag.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Tag Name',
-				id: 'tag',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/insitu/tag/off?markerName=${action.options.tag}`, 'POST')
-		},
-	}
-
-	actions.insituLayoutsOn = {
-		name: 'Insitu - Activate Layout',
-		description: 'Activate the specified Insitu layout.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Layout Name',
-				id: 'layout',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/insitu/layouts/on?layoutName=${action.options.layout}`, 'POST')
-		},
-	}
-
-	actions.insituPresetRecall = {
-		name: 'Insitu - Recall PTZ Preset',
-		description: 'Recalls a preset on a PTZ camera.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Camera Index',
-				id: 'cameraIndex',
-				default: '',
-			},
-			{
-				type: 'textinput',
-				label: 'Preset Index',
-				id: 'presetIndex',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(
-				self,
-				`/api/insitu/preset/recall/${action.options.cameraIndex}/${action.options.presetIndex}`,
-				'POST',
-			)
-		},
-	}
-
-	actions.insituLiveExtract = {
-		name: 'Insitu - Start/Stop Live Extract',
-		description: 'Starts or stops a live extract.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Action',
-				id: 'start',
-				default: 'true',
-				choices: [
-					{ id: 'true', label: 'Start' },
-					{ id: 'false', label: 'Stop' },
-				],
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/insitu/liveextract?start=${action.options.start}`, 'POST')
-		},
-	}*/
 
 	//MEDIALIST
 	actions.medialistSelect = {
@@ -450,359 +225,12 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v3/medialist/selected/${action.options.medialist}/select`, 'POST')
+			await SendCommand(self, `/api/v3/medialist/selected/${valueToString(action.options.medialist)}/select`, 'POST')
 			//Sync medialist items after selection
-			void runPollCycle(self)
+			void runPollScopes(self, ['medialist'], { forceSignalRRefresh: true })
 		},
 	}
 
-	//Selected Medialist Commands
-	actions.medialistPlay = {
-		name: 'MEDIALIST | Selected Medialist - Play',
-		description: 'Plays the currently selected Medialist',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v3/medialist/selected/play`, 'POST')
-		},
-	}
-
-	actions.medialistStop = {
-		name: 'MEDIALIST | Selected Medialist - Stop',
-		description: 'Stops the currently selected Medialist',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v3/medialist/selected/stop`, 'POST', true)
-		},
-	}
-
-	actions.medialistPause = {
-		name: 'MEDIALIST | Selected Medialist - Pause',
-		description: 'Pauses the currently selected Medialist',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v3/medialist/selected/pause`, 'POST')
-		},
-	}
-
-	actions.medialistMoveUp = {
-		name: 'MEDIALIST | Selected Medialist - Move Up',
-		description: 'Moves a media item up in the selected Medialist',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Media',
-				id: 'mediaId',
-				default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id || '',
-				choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v3/medialist/selected/${action.options.mediaId}/moveup`, 'POST')
-		},
-	}
-
-	actions.medialistMoveDown = {
-		name: 'MEDIALIST | Selected Medialist - Move Down',
-		description: 'Moves a media item down in the selected Medialist',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Media',
-				id: 'mediaId',
-				default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id || '',
-				choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v3/medialist/selected/${action.options.mediaId}/movedown`, 'POST')
-		},
-	}
-
-	actions.medialistPlayMedia = {
-		name: 'MEDIALIST | Selected Medialist - Select and Play Media',
-		description: 'Selects and plays the specified media in the selected Medialist',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Media',
-				id: 'mediaId',
-				default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id || '',
-				choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
-			},
-		],
-		callback: async (action) => {
-			const medialistId = action.options.medialistId as string
-			await SendCommand(self, `/api/v3/medialist/${medialistId}/play`, 'POST')
-		},
-	}
-
-	actions.medialistAddMedia = {
-		name: 'MEDIALIST | Selected Medialist - Add Media',
-		description: 'Adds a media to the selected Medialist',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Local Path to Media File',
-				id: 'mediaId',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			const path = await self.parseVariablesInString(String(action.options.mediaId))
-			await SendCommand(self, `/api/v3/medialist/selected/media`, 'POST', path)
-		},
-	}
-
-	//Custom Medialist Commands
-	actions.medialistPlayCustom = {
-		name: 'MEDIALIST | Custom Medialist - Play',
-		description: 'Plays the specified Medialist',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Medialist',
-				id: 'medialistId',
-				default: self.CHOICES_MEDIALISTS[0]?.id || '',
-				choices: self.CHOICES_MEDIALISTS,
-			},
-		],
-		callback: async (action) => {
-			const medialistId = action.options.medialistId as string
-			await SendCommand(self, `/api/v3/medialist/${medialistId}/play`, 'POST')
-		},
-	}
-
-	actions.medialistPlayMediaCustom = {
-		name: 'MEDIALIST | Custom Medialist - Select and Play Media',
-		description: 'Selects and plays the specified media in the specified Medialist',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Medialist / Media',
-				id: 'medialistMedia',
-				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id || '',
-				choices: self.CHOICES_MEDIALISTS_MEDIA,
-			},
-		],
-		callback: async (action) => {
-			const parsed = parseMedialistMediaGlobalChoiceId(String(action.options.medialistMedia ?? ''))
-			if (!parsed) return
-			await SendCommand(self, `/api/v3/medialist/${parsed.medialistId}/${parsed.mediaId}`, 'POST')
-		},
-	}
-
-	actions.medialistPlayMediaCustomByIndex = {
-		name: 'MEDIALIST | Custom Medialist - Select and Play Media By Index',
-		description: 'Selects and plays the specified media in the specified Medialist',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Medialist',
-				id: 'medialistId',
-				default: self.CHOICES_MEDIALISTS[0]?.id || '',
-				choices: self.CHOICES_MEDIALISTS,
-			},
-			{
-				type: 'textinput',
-				label: 'Media Index',
-				id: 'mediaIndex',
-				default: '0',
-				useVariables: true,
-			},
-		],
-		callback: async (action) => {
-			const medialistId = action.options.medialistId as string
-			const mediaIndex = await self.parseVariablesInString(String(action.options.mediaIndex))
-			await SendCommand(self, `/api/v3/medialist/${medialistId}/${mediaIndex}`, 'POST')
-		},
-	}
-
-	/*
-
-	//PUBLISHER
-	actions.publisherPublishRecording = {
-		name: 'Publisher - Publish Recording',
-		description: 'Starts publishing a recording using the specified workflow',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Workflow Name',
-				id: 'workflowName',
-				default: '',
-			},
-			{
-				type: 'textinput',
-				label: 'Recording ID',
-				id: 'recordingId',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/publisher/publish/${action.options.workflowName}/${action.options.recordingId}`)
-		},
-	}
-
-	//RADIO
-
-	actions.radioSetManualMic = {
-		name: 'Radio - Set Manual Mic',
-		description: 'Forces a specific microphone to be manually active',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Mic ID',
-				id: 'mic',
-				default: '',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/radio/microphones/man/${action.options.mic}`)
-		},
-	}
-
-	actions.radioSetWideShot = {
-		name: 'Radio - Wide Shot',
-		description: 'Forces a wide shot manually',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/radio/microphones/man/wide`)
-		},
-	}
-
-	actions.radioEnableAutoMic = {
-		name: 'Radio - Enable Auto Mic',
-		description: 'Enables automatic mic switching based on AI',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, '/api/v2/radio/microphones/auto')
-		},
-	}
-
-	actions.radioSetDynamism = {
-		name: 'Radio - Set AI Dynamism',
-		description: 'Sets the AI dynamism (0 to 10)',
-		options: [
-			{
-				type: 'number',
-				label: 'Dynamism (0–10)',
-				id: 'value',
-				default: 5,
-				min: 0,
-				max: 10,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, '/api/v2/radio/dynamism?score=' + String(action.options.value), 'POST')
-		},
-	}
-
-	actions.radioEnableAutoFrameFlow = {
-		name: 'Radio - Enable/Disable Auto FrameFlow',
-		description: 'Temporarily enables auto-framing before solos. Not persisted.',
-		options: [
-			{
-				type: 'checkbox',
-				label: 'Enable Auto FrameFlow',
-				id: 'enable',
-				default: true,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(
-				self,
-				`/api/v2/radio/autoFrameFlow/enable?desiredState=${Boolean(action.options.enable)}`,
-				'POST',
-			)
-		},
-	}
-
-	actions.radioSetPresetBank = {
-		name: 'Radio - Set Preset Bank',
-		description: 'Sets the current preset bank',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Bank',
-				id: 'bankId',
-				default: self.CHOICES_RADIO_PRESET_BANKS[0]?.id || '1',
-				choices: self.CHOICES_RADIO_PRESET_BANKS,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/radio/presetsbanks/current/${action.options.bankId}`)
-		},
-	}
-
-	actions.radioSetAutoTitling = {
-		name: 'Radio - Auto Titling On or Off',
-		description: 'Sets the state of the automatic titling (on/off)',
-		options: [
-			{
-				type: 'checkbox',
-				label: 'Enable Auto Titling',
-				id: 'enable',
-				default: true,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/radio/api/conf/autotitling?enable=${Boolean(action.options.enable)}`, 'POST')
-		},
-	}
-
-	actions.radioResetAutoTitling = {
-		name: 'Radio - Reset Auto Titling',
-		description: 'Resets the state of automatic titling',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v2/radio/api/conf/autotitling/reset`)
-		},
-	}
-
-	actions.radioSetAutomationRunning = {
-		name: 'Radio - Set Automation Running',
-		description: 'Enable or disable running state of automation',
-		options: [
-			{
-				type: 'checkbox',
-				label: 'Running',
-				id: 'running',
-				default: true,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/v2/radio/automation/running?enabled=${Boolean(action.options.running)}`, 'POST')
-		},
-	}
-
-	actions.radioOverrideCurrentProgram = {
-		name: 'Radio - Override Automation for Current Program',
-		description: 'Temporarily disables automation until next scene/take notification',
-		options: [
-			{
-				type: 'checkbox',
-				label: 'Override Current Program',
-				id: 'override',
-				default: true,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(
-				self,
-				`/api/v2/radio/automation/override-current-program?enabled=${Boolean(action.options.override)}`,
-				'POST',
-			)
-		},
-	}
-
-	actions.radioForceUpdateVariables = {
-		name: 'Radio - Force Update Automation Variables',
-		description: 'Triggers an update of declared automation variables',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, 'radio/automation/variables')
-		},
-	}
-	*/
 	//RECORDING
 	actions.recordingStart = {
 		name: 'RECORDING | Start',
@@ -826,28 +254,10 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			const duration = encodeURIComponent(String(action.options.duration ?? ''))
+			const duration = encodeURIComponent(valueToString(action.options.duration))
 			await SendCommand(self, `/api/recording/start/${duration}`, 'POST')
 		},
 	}
-
-	/* actions.recordingStartTracking = {
-		name: 'RECORDING | Start (Tracking)',
-		description: 'Starts recording using the Tracking application',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Duration (00:00:00)',
-				id: 'duration',
-				default: '00:01:00',
-				tooltip: 'Enter duration in HH:MM:SS format',
-			},
-		],
-		callback: async (action) => {
-			const duration = await self.parseVariablesInString(String(action.options.duration))
-			await SendCommand(self, 'api/recording/startRecording', 'POST', duration)
-		},
-	} */
 
 	actions.recordingStop = {
 		name: 'RECORDING | Stop',
@@ -867,34 +277,6 @@ export function UpdateActions(self: MulticamInstance): void {
 		},
 	}
 
-	/* actions.recordingLiveExtract = {
-		name: 'RECORDING | Live Extract Start/Stop',
-		description: 'Starts or stops a live extract recording',
-		options: [
-			{
-				type: 'checkbox',
-				label: 'Start Live Extract',
-				id: 'start',
-				default: true,
-			},
-			{
-				type: 'textinput',
-				label: 'Duration (in seconds)',
-				id: 'duration',
-				default: '0',
-			},
-		],
-		callback: async (action) => {
-			const duration = await self.parseVariablesInString(String(action.options.duration))
-			await SendCommand(
-				self,
-				`/api/recording/liveextract/start=${Boolean(action.options.start)}&duration=${duration}`,
-				'POST',
-			)
-		},
-	}
-	*/
-
 	actions.recordingIsoStart = {
 		name: 'RECORDING | Start All ISO Recordings',
 		description: 'Starts all configured ISO recordings',
@@ -913,40 +295,6 @@ export function UpdateActions(self: MulticamInstance): void {
 		},
 	}
 
-	actions.recordingIsoStartSource = {
-		name: 'RECORDING | Start ISO Recording',
-		description: 'Starts an ISO recording',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Source',
-				id: 'camId',
-				default: 'CAM1',
-			},
-		],
-		callback: async (action) => {
-			const camId = encodeURIComponent(String(action.options.camId ?? ''))
-			await SendCommand(self, `/api/recording/aux/start/${camId}`, 'POST')
-		},
-	}
-
-	actions.recordingIsoStopSource = {
-		name: 'RECORDING | Stop ISO Recording',
-		description: 'Stops an ISO recording',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Source',
-				id: 'camId',
-				default: 'CAM1',
-			},
-		],
-		callback: async (action) => {
-			const camId = encodeURIComponent(String(action.options.camId ?? ''))
-			await SendCommand(self, `/api/recording/aux/stop/${camId}`, 'POST')
-		},
-	}
-
 	/* actions.recordingSplit = {
 		name: 'RECORDING | Split',
 		description: 'Updates the split settings',
@@ -960,7 +308,7 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			const duration = await self.parseVariablesInString(String(action.options.duration))
+			const duration = String(action.options.duration ?? '')
 			await SendCommand(self, `/api/recording/split?newSplitDuration=${duration}`, 'POST')
 		},
 	} */
@@ -980,7 +328,7 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v2/scenes/selected/${action.options.fileId}`, 'POST')
+			await SendCommand(self, `/api/v2/scenes/selected/${valueToString(action.options.fileId)}`, 'POST')
 		},
 	}
 
@@ -997,7 +345,7 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v2/scenes/selected/${action.options.sceneId}/take`, 'POST')
+			await SendCommand(self, `/api/v2/scenes/selected/${valueToString(action.options.sceneId)}/take`, 'POST')
 		},
 	}
 
@@ -1014,7 +362,7 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v2/streaming/selected/${action.options.catalogId}`, 'POST')
+			await SendCommand(self, `/api/v2/streaming/selected/${valueToString(action.options.catalogId)}`, 'POST')
 		},
 	}
 
@@ -1046,7 +394,11 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v2/streaming/selected/profile/${action.options.profileId}/start`, 'POST')
+			await SendCommand(
+				self,
+				`/api/v2/streaming/selected/profile/${valueToString(action.options.profileId)}/start`,
+				'POST',
+			)
 		},
 	}
 
@@ -1062,56 +414,11 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v2/streaming/selected/profile/${action.options.profileId}/stop`, 'POST')
-		},
-	}
-
-	/* 	//STUDIO
-
-	actions.storePreset = {
-		name: 'Studio - Store Preset',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Camera Index',
-				id: 'cameraIndex',
-				default: '0',
-			},
-			{
-				type: 'textinput',
-				label: 'Preset Index',
-				id: 'presetIndex',
-				default: '0',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/studio/preset/store/${action.options.cameraIndex}/${action.options.presetIndex}`)
-		},
-	}
-
-	actions.autoframeCamera = {
-		name: 'Studio - Auto-Frame Camera',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Camera Index',
-				id: 'cameraIndex',
-				default: '0',
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(self, `/api/studio/autoframe/${action.options.cameraIndex}`)
-		},
-	}
- */
-	//SYSTEM
-
-	actions.shutdownSystem = {
-		name: 'SYSTEM | Shutdown',
-		description: 'Applies the shutdown action. This will stop all ongoing recordings, streamings and publishings.',
-		options: [],
-		callback: async () => {
-			await SendCommand(self, `/api/v1/system/shutdown`, 'POST')
+			await SendCommand(
+				self,
+				`/api/v2/streaming/selected/profile/${valueToString(action.options.profileId)}/stop`,
+				'POST',
+			)
 		},
 	}
 
@@ -1130,111 +437,11 @@ export function UpdateActions(self: MulticamInstance): void {
 			},
 		],
 		callback: async (action) => {
-			await SendCommand(self, `/api/v2/titler/selected/${action.options.fileId}`, 'POST')
-		},
-	}
-
-	actions.titlerElementVisible = {
-		name: 'TITLER | Set Element Visible/Invisible',
-		description: 'Sets the visibility of a Titler element.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Element',
-				id: 'elementId',
-				default: self.CHOICES_TITLER_ELEMENTS[0]?.id || '',
-				choices: self.CHOICES_TITLER_ELEMENTS,
-			},
-			{
-				type: 'checkbox',
-				label: 'Is On',
-				id: 'isOn',
-				default: true,
-			},
-			{
-				type: 'checkbox',
-				label: 'Is Animated',
-				id: 'isAnimate',
-				default: true,
-			},
-		],
-		callback: async (action) => {
-			await SendCommand(
-				self,
-				`/api/v2/titler/selected/elements/${action.options.elementId}/visible?isOn=${Boolean(
-					action.options.isOn,
-				)}&isAnimate=${Boolean(action.options.isAnimate)}`,
-				'POST',
-			)
-		},
-	}
-
-	//new action, Set Live Row of Speaker Entry of Element
-	actions.titlerSetSpeakerEntryLiveRow = {
-		name: 'TITLER | Set Titler Element Speaker Entry Live row',
-		description: 'Sets the Speaker live row of the Titler Element.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Element - Row',
-				id: 'rowId',
-				default: self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS[0]?.id || '',
-				choices: self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS,
-			},
-		],
-		callback: async (action) => {
-			//get elementId from actions.options.rowId -- elementId_speaker_rowId
-			const id: string = String(action.options.rowId)
-			const elementId = id.split('_speaker_')[0]
-			const rowId = id.split('_speaker_')[1]
-
-			await SendCommand(self, `/api/v2/titler/selected/elements/${elementId}/speaker/entries/${rowId}/live`, 'POST')
-		},
-	}
-
-	//Set Live Row of Panel Entry of Element
-	actions.titlerSetPanelEntryLiveRow = {
-		name: 'TITLER | Set Titler Element Panel Entry Live row',
-		description: 'Sets the Panel live row of the Titler Element.',
-		options: [
-			{
-				type: 'dropdown',
-				label: 'Element - Row',
-				id: 'rowId',
-				default: self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS[0]?.id || '',
-				choices: self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS,
-			},
-		],
-		callback: async (action) => {
-			//get elementId from actions.options.rowId -- elementId_panel_rowId
-			const id: string = String(action.options.rowId)
-			const elementId = id.split('_panel_')[0]
-			const rowId = id.split('_panel_')[1]
-			await SendCommand(self, `/api/v2/titler/selected/elements/${elementId}/panel/entries/${rowId}/live`, 'POST')
+			await SendCommand(self, `/api/v2/titler/selected/${valueToString(action.options.fileId)}`, 'POST')
 		},
 	}
 
 	//VIDEO
-	actions.videoChangeLiveSource = {
-		name: 'VIDEO | Change Live Source',
-		description: 'Changes the live video source.',
-		options: [
-			{
-				type: 'textinput',
-				label: 'Source Name',
-				id: 'sourceName',
-				default: 'Source 1',
-				required: true,
-				tooltip: '(ie "Source 1" or "PC Input" or "Medialist")',
-			},
-		],
-		callback: async (action) => {
-			const parsedName = await self.parseVariablesInString(String(action.options.sourceName))
-			const sourceName = encodeURIComponent(String(parsedName ?? ''))
-			await SendCommand(self, `/api/video/live/${sourceName}`, 'POST')
-		},
-	}
-
 	actions.videoRestartOutput = {
 		name: 'VIDEO | Restart Output',
 		description: 'Restarts the video output.',
@@ -1250,9 +457,2423 @@ export function UpdateActions(self: MulticamInstance): void {
 		description: 'Manually poll the application to update data.',
 		options: [],
 		callback: async () => {
-			void runPollCycle(self)
+			await runPollCycle(self, { forceSignalRRefresh: true })
 			self.log('info', 'Manual poll completed')
 		},
+	}
+
+	// API v1.4 actions are registered directly here and intentionally replace matching legacy definitions above.
+	const BOOLEAN_CHOICES = [
+		{ id: 'true', label: 'Enabled' },
+		{ id: 'false', label: 'Disabled' },
+	]
+
+	function logInvalidChoice(self: MulticamInstance, label: string): void {
+		self.log('error', `${label} is invalid. Refresh the module data and select it again.`)
+	}
+
+	function normalizeAutomationVariables(value: unknown): { Variables: { Key: string; Value: string }[] } | null {
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+		const record = value as Record<string, unknown>
+		if (Array.isArray(record.Variables)) {
+			const variables = record.Variables.filter(
+				(item): item is { Key: string; Value: string } =>
+					typeof item === 'object' && item !== null && typeof item.Key === 'string' && typeof item.Value === 'string',
+			)
+			return { Variables: variables }
+		}
+		return {
+			Variables: Object.entries(record).map(([Key, item]) => ({ Key, Value: valueToString(item) })),
+		}
+	}
+
+	// APPLICATION
+	actions.applicationStart = {
+		name: 'APPLICATION | Start',
+		description: 'Starts an application.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Application',
+				id: 'applicationName',
+				default: self.CHOICES_APPLICATIONS[0]?.id ?? 'none',
+				choices: self.CHOICES_APPLICATIONS,
+			},
+		],
+		callback: async (action) => {
+			await sendAndRefresh(self, `/api/application/start/${encodePathPart(action.options.applicationName)}`)
+		},
+	}
+
+	actions.applicationStartWithTemplate = {
+		name: 'APPLICATION | Start with Template',
+		description: 'Starts an application with one of its available templates.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Application - Template',
+				id: 'applicationTemplate',
+				default: self.CHOICES_APPLICATION_TEMPLATES[0]?.id ?? 'none',
+				choices: self.CHOICES_APPLICATION_TEMPLATES,
+			},
+			{
+				type: 'checkbox',
+				label: 'Wait for initialization to complete',
+				id: 'waitEndOfInit',
+				default: false,
+			},
+		],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.applicationTemplate, 2)
+			if (!parts) return logInvalidChoice(self, 'Application template')
+			await sendAndRefresh(
+				self,
+				`/api/application/startWithTemplate/${encodePathPart(parts[0])}/${encodePathPart(parts[1])}${buildQuery({
+					waitEndOfInit: Boolean(action.options.waitEndOfInit),
+				})}`,
+			)
+		},
+	}
+
+	actions.applicationStartWithRoom = {
+		name: 'APPLICATION | Start with Room',
+		description: 'Starts an application with a specified room.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Application',
+				id: 'applicationName',
+				default: self.CHOICES_APPLICATIONS[0]?.id ?? 'none',
+				choices: self.CHOICES_APPLICATIONS,
+			},
+			{
+				type: 'dropdown',
+				label: 'Room',
+				id: 'roomId',
+				default: self.CHOICES_ROOMS[0]?.id ?? 'none',
+				choices: self.CHOICES_ROOMS,
+			},
+			{
+				type: 'checkbox',
+				label: 'Wait for initialization to complete',
+				id: 'waitEndOfInit',
+				default: false,
+			},
+		],
+		callback: async (action) => {
+			await sendAndRefresh(
+				self,
+				`/api/application/startWithRoom/${encodePathPart(action.options.applicationName)}/${encodePathPart(
+					action.options.roomId,
+				)}${buildQuery({ waitEndOfInit: Boolean(action.options.waitEndOfInit) })}`,
+			)
+		},
+	}
+
+	actions.applicationRetryFailedStart = {
+		name: 'APPLICATION | Retry Failed Start',
+		description: 'Retries an application module which failed to start.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/application/retryFailedStart'),
+	}
+
+	actions.composerUntakeComposition = {
+		name: 'COMPOSER | Untake Composition',
+		description: 'Untakes the current composition using the documented empty composition ID.',
+		options: [],
+		callback: async () =>
+			sendAndRefresh(self, '/api/v3/composer/selected/compositions/selected/00000000-0000-0000-0000-000000000000'),
+	}
+
+	// AUDIO
+	actions.audioSelectProfile = {
+		name: 'AUDIO | Select Mixer Profile',
+		description: 'Selects an audio mixer profile by its ID.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Profile',
+				id: 'profileId',
+				default: self.CHOICES_AUDIO_PROFILES[0]?.id ?? 'none',
+				choices: self.CHOICES_AUDIO_PROFILES,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v1/audio/profiles/selected/${encodePathPart(action.options.profileId)}`),
+	}
+
+	// CAMERA
+	actions.cameraResetAll = {
+		name: 'CAMERA | Reset All',
+		description: 'Performs a reset operation on all initialized cameras.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v1/camera/reset/all'),
+	}
+
+	actions.cameraReset = {
+		name: 'CAMERA | Reset Camera',
+		description: 'Resets a specified camera.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera',
+				id: 'camId',
+				default: self.CHOICES_CAMERA_SOURCES[0]?.id ?? 'CAM1',
+				choices: self.CHOICES_CAMERA_SOURCES,
+			},
+		],
+		callback: async (action) => sendAndRefresh(self, `/api/v1/camera/reset/${encodePathPart(action.options.camId)}`),
+	}
+
+	actions.cameraAutoFraming = {
+		name: 'CAMERA | Set Auto Framing',
+		description: 'Toggles, enables or disables auto framing on a camera.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera',
+				id: 'camId',
+				default: self.CHOICES_CAMERA_SOURCES[0]?.id ?? 'CAM1',
+				choices: self.CHOICES_CAMERA_SOURCES,
+			},
+			{
+				type: 'dropdown',
+				label: 'Operation',
+				id: 'operation',
+				default: 'toggle',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'enable', label: 'Enable' },
+					{ id: 'disable', label: 'Disable' },
+				],
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v1/camera/api/video/autoframing/${encodePathPart(action.options.operation)}/${encodePathPart(
+					action.options.camId,
+				)}`,
+			),
+	}
+
+	// CONF V2
+	actions.confSetMicrophoneManual = {
+		name: 'CONF | Set Manual Microphone',
+		description: 'Sets manual mode and forces the selected microphone.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Microphone',
+				id: 'mic',
+				default: self.CHOICES_CONF_MICROPHONES[0]?.id ?? 'none',
+				choices: self.CHOICES_CONF_MICROPHONES,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/conf/microphones/man/${encodePathPart(action.options.mic)}`),
+	}
+
+	actions.confSetMicrophoneWide = {
+		name: 'CONF | Force Wide Shot',
+		description: 'Forces the wide shot in manual mode.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/conf/microphones/man/wide'),
+	}
+
+	actions.confSetMicrophonesAuto = {
+		name: 'CONF | Set Microphones Auto',
+		description: 'Sets microphone selection to automatic mode.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/conf/microphones/auto'),
+	}
+
+	actions.confSetDynamism = {
+		name: 'CONF | Set Dynamism',
+		description: 'Sets the AI dynamism from 0 to 10.',
+		options: [{ type: 'number', label: 'Dynamism', id: 'score', default: 5, min: 0, max: 10 }],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/conf/dynamism${buildQuery({ score: Number(action.options.score) })}`),
+	}
+
+	actions.confEnableAutoFrameFlow = {
+		name: 'CONF | Set Auto Frame Flow',
+		description: 'Controls AI auto framing before setting a solo preset live.',
+		options: [{ type: 'checkbox', label: 'Enable', id: 'desiredState', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/conf/autoFrameFlow/enable${buildQuery({ desiredState: Boolean(action.options.desiredState) })}`,
+			),
+	}
+
+	actions.confSetCurrentPresetBank = {
+		name: 'CONF | Select Preset Bank',
+		description: 'Sets the current preset bank by ID.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Preset Bank',
+				id: 'bankId',
+				default: self.CHOICES_CONF_PRESET_BANKS[0]?.id ?? 'none',
+				choices: self.CHOICES_CONF_PRESET_BANKS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/conf/presetsbanks/current/${encodePathPart(action.options.bankId)}`),
+	}
+
+	actions.confSetAutotitlingState = {
+		name: 'CONF | Set Automatic Titling',
+		description: 'Sets automatic titling on or off.',
+		options: [{ type: 'checkbox', label: 'Enable', id: 'enable', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/conf/api/conf/autotitling${buildQuery({ enable: Boolean(action.options.enable) })}`,
+			),
+	}
+
+	actions.confResetAutotitling = {
+		name: 'CONF | Reset Automatic Titling',
+		description: 'Resets automatic titling.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/conf/api/conf/autotitling/reset'),
+	}
+
+	// INSITU
+	actions.insituTagOn = {
+		name: 'INSITU | Activate Tag',
+		description: 'Activates an available Insitu tag.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Tag',
+				id: 'tag',
+				default: self.CHOICES_INSITU_TAGS[0]?.id ?? 'none',
+				choices: self.CHOICES_INSITU_TAGS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/insitu/tag/on${buildQuery({ markerName: action.options.tag })}`),
+	}
+
+	actions.insituTagOff = {
+		name: 'INSITU | Deactivate Tag',
+		description: 'Deactivates an Insitu tag.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Tag',
+				id: 'tag',
+				default: self.CHOICES_INSITU_TAGS[0]?.id ?? 'none',
+				choices: self.CHOICES_INSITU_TAGS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/insitu/tag/off${buildQuery({ markerName: action.options.tag })}`),
+	}
+
+	actions.insituLayoutsOn = {
+		name: 'INSITU | Activate Layout',
+		description: 'Activates an available Insitu layout.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Layout',
+				id: 'layout',
+				default: self.CHOICES_INSITU_LAYOUTS[0]?.id ?? 'none',
+				choices: self.CHOICES_INSITU_LAYOUTS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/insitu/layouts/on${buildQuery({ layoutName: action.options.layout })}`),
+	}
+
+	actions.insituPresetRecall = {
+		name: 'INSITU | Recall PTZ Preset',
+		description: 'Recalls one of the presets discovered from the active room cameras.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera - Preset',
+				id: 'preset',
+				default: self.CHOICES_INSITU_PRESETS[0]?.id ?? 'none',
+				choices: self.CHOICES_INSITU_PRESETS,
+			},
+		],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.preset, 2)
+			if (!parts) return logInvalidChoice(self, 'Insitu preset')
+			await sendAndRefresh(self, `/api/insitu/preset/recall/${encodePathPart(parts[0])}/${encodePathPart(parts[1])}`)
+		},
+	}
+
+	actions.insituLiveExtract = {
+		name: 'INSITU | Start/Stop Live Extract',
+		description: 'Starts or stops an Insitu live extract.',
+		options: [{ type: 'checkbox', label: 'Start', id: 'start', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/insitu/liveextract${buildQuery({ start: Boolean(action.options.start) })}`),
+	}
+
+	// PILOT
+	const pilotSequenceOption = {
+		type: 'dropdown' as const,
+		label: 'Camera - Sequence',
+		id: 'sequence',
+		default: self.CHOICES_PILOT_SEQUENCES[0]?.id ?? 'none',
+		choices: self.CHOICES_PILOT_SEQUENCES,
+	}
+
+	actions.pilotPrepareSequence = {
+		name: 'PILOT | Prepare Sequence',
+		description: 'Prepares a sequence from the active camera bank.',
+		options: [pilotSequenceOption, { type: 'checkbox', label: 'Show in UI', id: 'showInUI', default: true }],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.sequence, 2)
+			if (!parts) return logInvalidChoice(self, 'Pilot sequence')
+			await sendAndRefresh(
+				self,
+				`/api/v1/pilot/activebank/${encodePathPart(parts[0])}/sequence/${encodePathPart(
+					parts[1],
+				)}/prepare${buildQuery({ showInUI: Boolean(action.options.showInUI) })}`,
+			)
+		},
+	}
+
+	actions.pilotPlaySequence = {
+		name: 'PILOT | Play Sequence',
+		description: 'Plays a sequence from the active camera bank.',
+		options: [
+			pilotSequenceOption,
+			{ type: 'checkbox', label: 'Prepare first', id: 'prepare', default: true },
+			{ type: 'checkbox', label: 'Show in UI', id: 'showInUI', default: true },
+			{
+				type: 'dropdown',
+				label: 'Ping-pong',
+				id: 'pingPong',
+				default: '',
+				choices: [
+					{ id: '', label: 'Use UI setting' },
+					{ id: 'true', label: 'Enabled' },
+					{ id: 'false', label: 'Disabled (one-shot)' },
+				],
+			},
+		],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.sequence, 2)
+			if (!parts) return logInvalidChoice(self, 'Pilot sequence')
+			await sendAndRefresh(
+				self,
+				`/api/v1/pilot/activebank/${encodePathPart(parts[0])}/sequence/${encodePathPart(parts[1])}/play${buildQuery({
+					prepare: Boolean(action.options.prepare),
+					showInUI: Boolean(action.options.showInUI),
+					pingPong: action.options.pingPong,
+				})}`,
+			)
+		},
+	}
+
+	actions.pilotStopSequence = {
+		name: 'PILOT | Stop Sequence',
+		description: 'Stops a specified sequence.',
+		options: [pilotSequenceOption],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.sequence, 2)
+			if (!parts) return logInvalidChoice(self, 'Pilot sequence')
+			await sendAndRefresh(
+				self,
+				`/api/v1/pilot/activebank/${encodePathPart(parts[0])}/sequence/${encodePathPart(parts[1])}/stop`,
+			)
+		},
+	}
+
+	actions.pilotStopRunningSequence = {
+		name: 'PILOT | Stop Running Sequence',
+		description: 'Stops the running sequence, if any, for a camera.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera',
+				id: 'cam',
+				default: self.CHOICES_CAMERA_SOURCES[0]?.id ?? 'CAM1',
+				choices: self.CHOICES_CAMERA_SOURCES,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v1/pilot/activebank/${encodePathPart(action.options.cam)}/sequence/running/stop`),
+	}
+
+	// PUBLISHER
+	actions.publisherPublishRecording = {
+		name: 'PUBLISHER | Publish Recording',
+		description: 'Publishes a recording with a fully automated workflow.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Workflow',
+				id: 'workflowName',
+				default: self.CHOICES_PUBLISHER_WORKFLOWS[0]?.id ?? 'none',
+				choices: self.CHOICES_PUBLISHER_WORKFLOWS,
+			},
+			{
+				type: 'dropdown',
+				label: 'Recording',
+				id: 'recordingId',
+				default: self.CHOICES_PUBLISHER_RECORDINGS[0]?.id ?? 'none',
+				choices: self.CHOICES_PUBLISHER_RECORDINGS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/publisher/publish/${encodePathPart(action.options.workflowName)}/${encodePathPart(
+					action.options.recordingId,
+				)}`,
+			),
+	}
+
+	actions.publisherDeleteRecording = {
+		name: 'PUBLISHER | Delete Recording',
+		description: 'Deletes the selected recording.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Recording',
+				id: 'recordingId',
+				default: self.CHOICES_PUBLISHER_RECORDINGS[0]?.id ?? 'none',
+				choices: self.CHOICES_PUBLISHER_RECORDINGS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/publisher/recording/${encodePathPart(action.options.recordingId)}`, 'DELETE'),
+	}
+
+	actions.publisherDeleteUnavailableRecordings = {
+		name: 'PUBLISHER | Delete Unavailable Recordings',
+		description: 'Removes database entries whose recording files are no longer available.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/publisher/recording/unavailables', 'DELETE'),
+	}
+
+	actions.publisherRenameRecording = {
+		name: 'PUBLISHER | Rename Recording',
+		description: 'Renames the selected recording.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Recording',
+				id: 'recordingId',
+				default: self.CHOICES_PUBLISHER_RECORDINGS[0]?.id ?? 'none',
+				choices: self.CHOICES_PUBLISHER_RECORDINGS,
+			},
+			{ type: 'textinput', label: 'New Name', id: 'newName', default: '', useVariables: true },
+		],
+		callback: async (action) => {
+			const newName = await expandOption(self, action.options.newName)
+			await sendAndRefresh(
+				self,
+				`/api/publisher/recording/${encodePathPart(action.options.recordingId)}/${encodePathPart(newName)}`,
+				'PUT',
+			)
+		},
+	}
+
+	// RADIO V2
+	actions.radioSetManualMic = {
+		name: 'RADIO | Set Manual Microphone',
+		description: 'Sets manual mode and forces a microphone.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Microphone',
+				id: 'mic',
+				default: self.CHOICES_RADIO_MICROPHONES[0]?.id ?? 'none',
+				choices: self.CHOICES_RADIO_MICROPHONES,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/radio/microphones/man/${encodePathPart(action.options.mic)}`),
+	}
+
+	actions.radioSetWideShot = {
+		name: 'RADIO | Force Wide Shot',
+		description: 'Forces the wide shot in manual mode.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/radio/microphones/man/wide'),
+	}
+
+	actions.radioEnableAutoMic = {
+		name: 'RADIO | Set Microphones Auto',
+		description: 'Sets microphone selection to automatic mode.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/radio/microphones/auto'),
+	}
+
+	actions.radioSetDynamism = {
+		name: 'RADIO | Set Dynamism',
+		description: 'Sets the AI dynamism from 0 to 10.',
+		options: [{ type: 'number', label: 'Dynamism', id: 'value', default: 5, min: 0, max: 10 }],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/radio/dynamism${buildQuery({ score: Number(action.options.value) })}`),
+	}
+
+	actions.radioEnableAutoFrameFlow = {
+		name: 'RADIO | Set Auto Frame Flow',
+		description: 'Controls AI auto framing before a solo preset is set live.',
+		options: [{ type: 'checkbox', label: 'Enable', id: 'enable', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/radio/autoFrameFlow/enable${buildQuery({ desiredState: Boolean(action.options.enable) })}`,
+			),
+	}
+
+	actions.radioOverrideAutoFrameFlow = {
+		name: 'RADIO | Override Continuous Auto Frame',
+		description: 'Temporarily allows or prevents continuous auto framing.',
+		options: [{ type: 'checkbox', label: 'Allow', id: 'doAllow', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/radio/autoFrameFlow/override/${Boolean(action.options.doAllow)}`),
+	}
+
+	actions.radioSetPresetBank = {
+		name: 'RADIO | Select Preset Bank',
+		description: 'Sets the current preset bank.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Preset Bank',
+				id: 'bankId',
+				default: self.CHOICES_RADIO_PRESET_BANKS[0]?.id ?? 'none',
+				choices: self.CHOICES_RADIO_PRESET_BANKS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v2/radio/presetsbanks/current/${encodePathPart(action.options.bankId)}`),
+	}
+
+	actions.radioSetAutoTitling = {
+		name: 'RADIO | Set Automatic Titling',
+		description: 'Sets automatic titling on or off.',
+		options: [{ type: 'checkbox', label: 'Enable', id: 'enable', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/radio/api/conf/autotitling${buildQuery({ enable: Boolean(action.options.enable) })}`,
+			),
+	}
+
+	actions.radioResetAutoTitling = {
+		name: 'RADIO | Reset Automatic Titling',
+		description: 'Resets automatic titling.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/radio/api/conf/autotitling/reset'),
+	}
+
+	actions.radioSetAutomationRunning = {
+		name: 'RADIO | Set Automation Running',
+		description: 'Enables or disables playout automation.',
+		options: [{ type: 'checkbox', label: 'Running', id: 'running', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/radio/automation/running${buildQuery({ enabled: Boolean(action.options.running) })}`,
+			),
+	}
+
+	actions.radioOverrideCurrentProgram = {
+		name: 'RADIO | Override Current Program Automation',
+		description: 'Temporarily disables or restores scene automation for the current program.',
+		options: [{ type: 'checkbox', label: 'Override', id: 'override', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/radio/automation/override-current-program${buildQuery({
+					enabled: Boolean(action.options.override),
+				})}`,
+			),
+	}
+
+	actions.radioSetAutomationVariables = {
+		name: 'RADIO | Set Automation Variables',
+		description: 'Updates automation variables. Accepts either an object or the documented Variables payload.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Update Mode',
+				id: 'mode',
+				default: 'PUT',
+				choices: [
+					{ id: 'PUT', label: 'Merge (keep undeclared variables)' },
+					{ id: 'POST', label: 'Replace (clear undeclared variables)' },
+				],
+			},
+			{
+				type: 'textinput',
+				label: 'Variables JSON',
+				id: 'variables',
+				default: '{"Example":"Value"}',
+				useVariables: true,
+				tooltip: 'Either {"Key":"Value"} or {"Variables":[{"Key":"Key","Value":"Value"}]}',
+			},
+		],
+		callback: async (action) => {
+			const parsed = await parseJsonOption<unknown>(self, action.options.variables, 'Automation variables')
+			if (parsed === undefined) return
+			const payload = normalizeAutomationVariables(parsed)
+			if (!payload) {
+				self.log('error', 'Automation variables JSON must be an object')
+				return
+			}
+			await sendAndRefresh(self, '/api/v2/radio/automation/variables', valueToString(action.options.mode), payload)
+		},
+	}
+
+	actions.radioClearAutomationVariables = {
+		name: 'RADIO | Clear Automation Variables',
+		description: 'Clears declared playout automation variables.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v2/radio/automation/variables', 'DELETE'),
+	}
+
+	// RECORDING
+	actions.recordingSplit = {
+		name: 'RECORDING | Set Split Duration',
+		description: 'Sets the split duration to 5–320 minutes. Zero disables splitting.',
+		options: [
+			{
+				type: 'number',
+				label: 'Duration (0 = disabled, or 5–320 minutes)',
+				id: 'duration',
+				default: 0,
+				min: 0,
+				max: 320,
+				step: 1,
+				asInteger: true,
+				tooltip: 'Use 0 to disable splitting. Values from 1 through 4 are not supported by Multicam.',
+			},
+		],
+		callback: async (action) => {
+			const duration = Number(action.options.duration)
+			if (!Number.isInteger(duration) || (duration !== 0 && (duration < 5 || duration > 320))) {
+				self.log('error', 'Split duration must be 0 (disabled) or an integer between 5 and 320 minutes.')
+				return
+			}
+			await sendAndRefresh(self, `/api/recording/split${buildQuery({ newSplitDuration: duration })}`)
+		},
+	}
+
+	actions.recordingStartTracking = {
+		name: 'RECORDING | Start Tracking Recording',
+		description: 'Starts a Tracking recording with a duration value in the request body.',
+		options: [
+			{
+				type: 'textinput',
+				label: 'Duration (HH:MM:SS)',
+				id: 'duration',
+				default: '00:01:00',
+				useVariables: true,
+			},
+		],
+		callback: async (action) => {
+			const duration = await expandOption(self, action.options.duration)
+			await sendAndRefresh(self, '/api/recording/startRecording', 'POST', duration)
+		},
+	}
+
+	actions.recordingLiveExtract = {
+		name: 'RECORDING | Start/Stop Live Extract',
+		description: 'Starts or stops a live extract and optionally specifies its duration.',
+		options: [
+			{ type: 'checkbox', label: 'Start', id: 'start', default: true },
+			{ type: 'number', label: 'Duration (seconds)', id: 'duration', default: 0, min: 0, max: 86400 },
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/recording/liveextract${buildQuery({
+					start: Boolean(action.options.start),
+					duration: Number(action.options.duration),
+				})}`,
+			),
+	}
+
+	for (const [id, name, endpoint] of [
+		['recordingIsoStartSource', 'RECORDING | Start ISO Recording', '/api/recording/aux/start'],
+		['recordingIsoStopSource', 'RECORDING | Stop ISO Recording', '/api/recording/aux/stop'],
+	] as const) {
+		actions[id] = {
+			name,
+			description: `${name} for a selected video source.`,
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Source',
+					id: 'camId',
+					default: self.CHOICES_RECORDING_AUX_SOURCES[0]?.id ?? 'Source 1',
+					choices: self.CHOICES_RECORDING_AUX_SOURCES,
+				},
+			],
+			callback: async (action) => {
+				const camId = normalizeRecordingAuxSource(action.options.camId)
+				if (!camId) {
+					self.log('error', 'ISO recording source is invalid. Select Source 1–40 or another supported source.')
+					return
+				}
+				await sendAndRefresh(self, `${endpoint}/${encodePathPart(camId)}`)
+			},
+		}
+	}
+
+	// STREAMING V2
+	actions.streamingUpdateProfile = {
+		name: 'STREAMING | Update Profile',
+		description: 'Gets the current profile, merges the requested fields, then sends the complete PUT payload.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Profile',
+				id: 'profileId',
+				default: self.CHOICES_STREAMING_PROFILES[0]?.id ?? 'none',
+				choices: self.CHOICES_STREAMING_PROFILES,
+			},
+			{
+				type: 'dropdown',
+				label: 'Enabled',
+				id: 'enabled',
+				default: 'keep',
+				choices: [{ id: 'keep', label: 'Keep current value' }, ...BOOLEAN_CHOICES],
+			},
+			{
+				type: 'textinput',
+				label: 'Profile Name (blank keeps current)',
+				id: 'name',
+				default: '',
+				useVariables: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Broadcast Server Hostname (blank keeps current)',
+				id: 'hostname',
+				default: '',
+				useVariables: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Broadcast Stream ID (blank keeps current)',
+				id: 'streamId',
+				default: '',
+				useVariables: true,
+			},
+		],
+		callback: async (action) => {
+			const profileId = valueToString(action.options.profileId)
+			const endpoint = `/api/v2/streaming/selected/profile/${encodePathPart(profileId)}`
+			const current = await SendCommand(self, endpoint)
+			if (typeof current !== 'object' || current === null || Array.isArray(current)) {
+				self.log('error', `Unable to get streaming profile ${profileId} before update`)
+				return
+			}
+			const payload = { ...current }
+			if (action.options.enabled !== 'keep') payload.IsEnabled = action.options.enabled === 'true'
+			const name = await expandOption(self, action.options.name)
+			const hostname = await expandOption(self, action.options.hostname)
+			const streamId = await expandOption(self, action.options.streamId)
+			if (name) payload.Name = name
+			if (hostname) payload.BroadcastServerHostname = hostname
+			if (streamId) payload.BroadcastStreamID = streamId
+			await sendAndRefresh(self, endpoint, 'PUT', payload)
+		},
+	}
+
+	// STUDIO
+	actions.studioRecallPresetAndSetLive = {
+		name: 'STUDIO | Recall Preset and Set Live',
+		description: 'Recalls a discovered preset and sets its camera live.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera - Preset',
+				id: 'preset',
+				default: self.CHOICES_STUDIO_PRESETS[0]?.id ?? 'none',
+				choices: self.CHOICES_STUDIO_PRESETS,
+			},
+		],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.preset, 2)
+			if (!parts) return logInvalidChoice(self, 'Studio preset')
+			await sendAndRefresh(
+				self,
+				`/api/studio/recallpresetandsetlive/${encodePathPart(parts[0])}/${encodePathPart(parts[1])}`,
+				'GET',
+			)
+		},
+	}
+
+	actions.studioRecallPreset = {
+		name: 'STUDIO | Recall Preset',
+		description: 'Recalls a discovered PTZ preset.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera - Preset',
+				id: 'preset',
+				default: self.CHOICES_STUDIO_PRESETS[0]?.id ?? 'none',
+				choices: self.CHOICES_STUDIO_PRESETS,
+			},
+			{ type: 'checkbox', label: 'Allow recall on live camera', id: 'allowLive', default: false },
+		],
+		callback: async (action) => {
+			const parts = parseCompositeChoiceId(action.options.preset, 2)
+			if (!parts) return logInvalidChoice(self, 'Studio preset')
+			await sendAndRefresh(
+				self,
+				`/api/studio/preset/recall/${encodePathPart(parts[0])}/${encodePathPart(parts[1])}/${Boolean(
+					action.options.allowLive,
+				)}`,
+				'GET',
+			)
+		},
+	}
+
+	actions.storePreset = {
+		name: 'STUDIO | Store Preset',
+		description: 'Stores the current camera position in a preset slot.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera',
+				id: 'cameraIndex',
+				default: self.CHOICES_CAMERA_INDEXES[0]?.id ?? '0',
+				choices: self.CHOICES_CAMERA_INDEXES,
+			},
+			{ type: 'number', label: 'Preset Index', id: 'presetIndex', default: 0, min: 0, max: 5 },
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/studio/preset/store/${encodePathPart(action.options.cameraIndex)}/${encodePathPart(
+					action.options.presetIndex,
+				)}`,
+			),
+	}
+
+	actions.autoframeCamera = {
+		name: 'STUDIO | Auto Frame Camera',
+		description: 'Attempts auto framing on the selected camera.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Camera',
+				id: 'cameraIndex',
+				default: self.CHOICES_CAMERA_INDEXES[0]?.id ?? '0',
+				choices: self.CHOICES_CAMERA_INDEXES,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/studio/autoframe/${encodePathPart(action.options.cameraIndex)}`),
+	}
+
+	// VIDEO
+	actions.videoChangeLiveSource = {
+		name: 'VIDEO | Change Live Source',
+		description: 'Changes the live source using the sources reported by the video mixer.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Source',
+				id: 'sourceName',
+				default: self.CHOICES_VIDEO_SOURCES[0]?.id ?? 'Source 1',
+				choices: self.CHOICES_VIDEO_SOURCES,
+				disableAutoExpression: true,
+			},
+		],
+		callback: async (action) => sendAndRefresh(self, `/api/video/live/${encodePathPart(action.options.sourceName)}`),
+	}
+
+	// Advanced API actions
+	function invalidChoice(self: MulticamInstance, label: string): void {
+		self.log('error', `${label} is invalid. Refresh module data and select it again.`)
+	}
+
+	function isRecord(value: unknown): value is Record<string, any> {
+		return typeof value === 'object' && value !== null && !Array.isArray(value)
+	}
+
+	type TitlerEntryKind = 'speaker' | 'panel'
+
+	type TitlerColumnDefinition = {
+		name: string
+		type: string
+		isDisplayOptional: boolean
+	}
+
+	function getTitlerColumnDefinitions(structure: unknown): TitlerColumnDefinition[] {
+		if (!isRecord(structure)) return []
+		const definitions = structure.ColumnDefinitions ?? structure.columnDefinitions
+		if (!Array.isArray(definitions)) return []
+
+		return definitions.flatMap((definition: unknown) => {
+			if (!isRecord(definition)) return []
+			const name = String(definition.Name ?? definition.name ?? '').trim()
+			if (!name) return []
+			return [
+				{
+					name,
+					type: String(definition.Type ?? definition.type ?? 'Text'),
+					isDisplayOptional: Boolean(definition.IsDisplayOptional ?? definition.isDisplayOptional),
+				},
+			]
+		})
+	}
+
+	function makeStableOptionToken(value: string): string {
+		let hash = 0x811c9dc5
+		for (let index = 0; index < value.length; index++) {
+			hash ^= value.charCodeAt(index)
+			hash = Math.imul(hash, 0x01000193)
+		}
+		return (hash >>> 0).toString(36)
+	}
+
+	function makeTitlerColumnOptionId(
+		kind: TitlerEntryKind,
+		elementId: string,
+		columnName: string,
+		columnIndex: number,
+	): string {
+		return `entry_${kind}_${columnIndex}_${makeStableOptionToken(`${elementId}\u0000${columnName}`)}`
+	}
+
+	function makeTitlerRowColumnOptionId(
+		kind: TitlerEntryKind,
+		elementId: string,
+		rowId: string,
+		columnName: string,
+		columnIndex: number,
+	): string {
+		return `row_entry_${kind}_${columnIndex}_${makeStableOptionToken(`${elementId}\u0000${rowId}\u0000${columnName}`)}`
+	}
+
+	function makeTitlerRowDataLinkOptionId(kind: TitlerEntryKind, elementId: string, rowId: string): string {
+		return `row_datalink_${kind}_${makeStableOptionToken(`${elementId}\u0000${rowId}`)}`
+	}
+
+	function visibleForElement(elementId: string): string {
+		return `$(options:elementId) == ${JSON.stringify(elementId)}`
+	}
+
+	function visibleForRow(rowChoiceId: string): string {
+		return `$(options:rowId) == ${JSON.stringify(rowChoiceId)}`
+	}
+
+	function parseTitlerRowChoice(value: unknown, kind: 'speaker' | 'panel'): [string, string] | null {
+		const token = `_${kind}_`
+		const id = valueToString(value)
+		const separator = id.indexOf(token)
+		if (separator <= 0 || separator + token.length >= id.length) return null
+		return [id.slice(0, separator), id.slice(separator + token.length)]
+	}
+
+	function normalizeEntries(value: unknown, label: string): Record<string, string> | undefined {
+		const entries = value
+		if (!isRecord(entries)) {
+			self.log('error', `${label} must be a JSON object`)
+			return undefined
+		}
+
+		const normalized: Record<string, string> = {}
+		for (const [name, entryValue] of Object.entries(entries)) {
+			if (entryValue === null || entryValue === undefined) {
+				normalized[name] = ''
+			} else if (['string', 'number', 'boolean'].includes(typeof entryValue)) {
+				normalized[name] = String(entryValue)
+			} else {
+				self.log('error', `${label} value "${name}" must be a text, number, boolean or null value`)
+				return undefined
+			}
+		}
+		return normalized
+	}
+
+	async function parseEntries(value: unknown): Promise<Record<string, string> | undefined> {
+		const entries = await parseJsonOption<unknown>(self, value, 'Titler entries')
+		return entries === undefined ? undefined : normalizeEntries(entries, 'Titler entries')
+	}
+
+	function getTitlerStructure(elementId: string, kind: TitlerEntryKind): Record<string, any> | undefined {
+		const structure = self.TITLER_ELEMENT_STRUCTURES[`${elementId}:${kind}`]
+		return isRecord(structure) ? structure : undefined
+	}
+
+	function getTitlerRows(elementId: string, kind: TitlerEntryKind): any[] {
+		const element = self.TITLER_SELECTED_FILE_ELEMENTS.find(
+			(candidate: any) => String(candidate?.Id ?? '') === elementId,
+		)
+		const rows = kind === 'panel' ? element?.PanelEntries : element?.SpeakerEntries
+		return Array.isArray(rows) ? rows : []
+	}
+
+	function getTitlerRow(elementId: string, kind: TitlerEntryKind, rowId: string): Record<string, any> | undefined {
+		const row = getTitlerRows(elementId, kind).find((candidate: any) => String(candidate?.Id ?? '') === rowId)
+		return isRecord(row) ? row : undefined
+	}
+
+	function buildPanelEntryOptions(): SomeCompanionActionInputField[] {
+		const options: SomeCompanionActionInputField[] = [
+			{
+				type: 'dropdown',
+				label: 'Panel Element',
+				id: 'elementId',
+				default: self.CHOICES_TITLER_PANEL_ELEMENTS[0]?.id ?? 'none',
+				choices: self.CHOICES_TITLER_PANEL_ELEMENTS,
+				disableAutoExpression: true,
+				description: 'Select a Panel to load its columns automatically.',
+			},
+		]
+
+		for (const element of self.CHOICES_TITLER_PANEL_ELEMENTS) {
+			const elementId = String(element.id)
+			const structure = getTitlerStructure(elementId, 'panel')
+			const columns = getTitlerColumnDefinitions(structure)
+			const visibility = visibleForElement(elementId)
+			const infoId = `panel_columns_${makeStableOptionToken(elementId)}`
+
+			if (columns.length === 0) {
+				options.push({
+					type: 'static-text',
+					label: 'Panel Columns',
+					id: infoId,
+					value:
+						elementId.toLowerCase() === 'none'
+							? 'No Panel is currently available.'
+							: 'The Panel structure has not been loaded yet. Start Titler and wait for the module refresh.',
+					isVisibleExpression: visibility,
+				})
+				continue
+			}
+
+			const dataLinkElement = String(structure?.DataLinkElement ?? structure?.dataLinkElement ?? '').trim()
+			const isDataLinked = Boolean(structure?.IsDataLinked ?? structure?.isDataLinked)
+			options.push({
+				type: 'static-text',
+				label: 'Panel Columns',
+				id: infoId,
+				value: `${columns.length} column${columns.length === 1 ? '' : 's'} detected automatically.${
+					isDataLinked ? ` Data-linked${dataLinkElement ? ` to ${dataLinkElement}` : ''}.` : ''
+				}`,
+				isVisibleExpression: visibility,
+			})
+
+			for (const [columnIndex, column] of columns.entries()) {
+				const isImage = column.type.toLowerCase() === 'image'
+				options.push({
+					type: 'textinput',
+					label: `${column.name}${column.isDisplayOptional ? ' (display optional)' : ''}${isImage ? ' [Image]' : ''}`,
+					id: makeTitlerColumnOptionId('panel', elementId, column.name, columnIndex),
+					default: '',
+					useVariables: true,
+					description: isImage
+						? 'Enter the image/media value expected by Multicam.'
+						: 'The column name and Entries object are generated automatically.',
+					isVisibleExpression: visibility,
+				})
+			}
+		}
+
+		options.push(
+			{
+				type: 'textinput',
+				label: 'Data Link Parameter',
+				id: 'dataLinkParameter',
+				default: '',
+				useVariables: true,
+				description: 'Only needed by data-linked Panels.',
+			},
+			{
+				type: 'checkbox',
+				label: 'Show Advanced JSON Override',
+				id: 'showAdvancedEntries',
+				default: false,
+				disableAutoExpression: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Advanced Entries Override (JSON object)',
+				id: 'entries',
+				default: '{}',
+				useVariables: true,
+				isVisibleExpression: '$(options:showAdvancedEntries)',
+				description: 'Optional. These values are merged over the automatically generated columns.',
+			},
+		)
+
+		return options
+	}
+
+	function buildPanelUpdateRowOptions(
+		rowChoices: Array<{ id: string; label: string }>,
+	): SomeCompanionActionInputField[] {
+		const options: SomeCompanionActionInputField[] = [
+			{
+				type: 'dropdown',
+				label: 'Element - Row',
+				id: 'rowId',
+				default: rowChoices[0]?.id ?? 'none',
+				choices: rowChoices,
+				disableAutoExpression: true,
+				description: 'Select a Panel row to load its current values automatically.',
+			},
+		]
+
+		for (const rowChoice of rowChoices) {
+			const rowChoiceId = String(rowChoice.id)
+			const parts = parseTitlerRowChoice(rowChoiceId, 'panel')
+			const visibility = visibleForRow(rowChoiceId)
+			const infoId = `panel_update_row_${makeStableOptionToken(rowChoiceId)}`
+
+			if (!parts) {
+				options.push({
+					type: 'static-text',
+					label: 'Panel Row',
+					id: infoId,
+					value: 'No Panel row is currently available.',
+					isVisibleExpression: visibility,
+				})
+				continue
+			}
+
+			const [elementId, rowId] = parts
+			const columns = getTitlerColumnDefinitions(getTitlerStructure(elementId, 'panel'))
+			const row = getTitlerRow(elementId, 'panel', rowId)
+			options.push({
+				type: 'static-text',
+				label: 'Panel Row',
+				id: infoId,
+				value:
+					columns.length > 0
+						? `${columns.length} column${columns.length === 1 ? '' : 's'} loaded from the selected row.`
+						: 'The Panel structure has not been loaded yet. Start Titler and wait for the module refresh.',
+				isVisibleExpression: visibility,
+			})
+
+			for (const [columnIndex, column] of columns.entries()) {
+				const isImage = column.type.toLowerCase() === 'image'
+				options.push({
+					type: 'textinput',
+					label: `${column.name}${column.isDisplayOptional ? ' (display optional)' : ''}${isImage ? ' [Image]' : ''}`,
+					id: makeTitlerRowColumnOptionId('panel', elementId, rowId, column.name, columnIndex),
+					default: valueToString(row?.Entries?.[column.name] ?? ''),
+					useVariables: true,
+					isVisibleExpression: visibility,
+				})
+			}
+
+			options.push({
+				type: 'textinput',
+				label: 'Data Link Parameter',
+				id: makeTitlerRowDataLinkOptionId('panel', elementId, rowId),
+				default: valueToString(row?.DataLinkParameter ?? ''),
+				useVariables: true,
+				isVisibleExpression: visibility,
+			})
+		}
+
+		options.push(
+			{ type: 'checkbox', label: 'Replace All Entries', id: 'replaceEntries', default: false },
+			{
+				type: 'checkbox',
+				label: 'Show Advanced JSON Override',
+				id: 'showAdvancedEntries',
+				default: false,
+				disableAutoExpression: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Advanced Entries Override (JSON object)',
+				id: 'entries',
+				default: '{}',
+				useVariables: true,
+				isVisibleExpression: '$(options:showAdvancedEntries)',
+			},
+			{
+				type: 'textinput',
+				label: 'Advanced Data Link Parameter',
+				id: 'dataLinkParameter',
+				default: '',
+				useVariables: true,
+				isVisibleExpression: '$(options:showAdvancedEntries)',
+			},
+			{ type: 'checkbox', label: 'Reset Auto-Off Timer', id: 'resetTimer', default: true },
+		)
+
+		return options
+	}
+
+	function buildPanelUpdateAllOptions(): SomeCompanionActionInputField[] {
+		const options: SomeCompanionActionInputField[] = [
+			{
+				type: 'dropdown',
+				label: 'Panel Element',
+				id: 'elementId',
+				default: self.CHOICES_TITLER_PANEL_ELEMENTS[0]?.id ?? 'none',
+				choices: self.CHOICES_TITLER_PANEL_ELEMENTS,
+				disableAutoExpression: true,
+				description: 'Select a Panel to load every existing row and column automatically.',
+			},
+		]
+
+		for (const element of self.CHOICES_TITLER_PANEL_ELEMENTS) {
+			const elementId = String(element.id)
+			const visibility = visibleForElement(elementId)
+			const columns = getTitlerColumnDefinitions(getTitlerStructure(elementId, 'panel'))
+			const rows = getTitlerRows(elementId, 'panel')
+			const infoId = `panel_update_all_${makeStableOptionToken(elementId)}`
+			options.push({
+				type: 'static-text',
+				label: 'Panel Rows',
+				id: infoId,
+				value:
+					columns.length === 0
+						? 'The Panel structure has not been loaded yet. Start Titler and wait for the module refresh.'
+						: rows.length === 0
+							? 'This Panel has no existing rows. Use Add Panel Entry first.'
+							: `${rows.length} row${rows.length === 1 ? '' : 's'} and ${columns.length} column${
+									columns.length === 1 ? '' : 's'
+								} loaded automatically.`,
+				isVisibleExpression: visibility,
+			})
+
+			for (const [rowIndex, row] of rows.entries()) {
+				const rowId = valueToString(row?.Id)
+				if (!rowId) continue
+				const currentValues = columns
+					.map((column) => valueToString(row?.Entries?.[column.name]))
+					.filter(Boolean)
+					.join(' - ')
+				options.push({
+					type: 'static-text',
+					label: `Row ${rowIndex + 1}`,
+					id: `panel_update_all_row_${makeStableOptionToken(`${elementId}\u0000${rowId}`)}`,
+					value: currentValues || rowId,
+					isVisibleExpression: visibility,
+				})
+
+				for (const [columnIndex, column] of columns.entries()) {
+					const isImage = column.type.toLowerCase() === 'image'
+					options.push({
+						type: 'textinput',
+						label: `Row ${rowIndex + 1} - ${column.name}${
+							column.isDisplayOptional ? ' (display optional)' : ''
+						}${isImage ? ' [Image]' : ''}`,
+						id: makeTitlerRowColumnOptionId('panel', elementId, rowId, column.name, columnIndex),
+						default: valueToString(row?.Entries?.[column.name] ?? ''),
+						useVariables: true,
+						isVisibleExpression: visibility,
+					})
+				}
+
+				options.push({
+					type: 'textinput',
+					label: `Row ${rowIndex + 1} - Data Link Parameter`,
+					id: makeTitlerRowDataLinkOptionId('panel', elementId, rowId),
+					default: valueToString(row?.DataLinkParameter ?? ''),
+					useVariables: true,
+					isVisibleExpression: visibility,
+				})
+			}
+		}
+
+		options.push(
+			{
+				type: 'checkbox',
+				label: 'Use Advanced Rows JSON',
+				id: 'showAdvancedRows',
+				default: false,
+				disableAutoExpression: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Advanced Rows Override (JSON array)',
+				id: 'rows',
+				default: '[]',
+				useVariables: true,
+				isVisibleExpression: '$(options:showAdvancedRows)',
+			},
+			{ type: 'checkbox', label: 'Reset Auto-Off Timer', id: 'resetTimer', default: true },
+		)
+
+		return options
+	}
+
+	function normalizePanelRows(value: unknown): Record<string, unknown>[] | undefined {
+		if (!Array.isArray(value)) {
+			self.log('error', 'Panel rows must be a JSON array')
+			return undefined
+		}
+
+		const normalizedRows: Record<string, unknown>[] = []
+		for (const [rowIndex, row] of value.entries()) {
+			if (!isRecord(row)) {
+				self.log('error', `Panel row ${rowIndex + 1} must be a JSON object`)
+				return undefined
+			}
+			const entries = normalizeEntries(row.Entries ?? row.entries ?? {}, `Panel row ${rowIndex + 1} Entries`)
+			if (!entries) return undefined
+
+			const normalizedRow: Record<string, unknown> = {
+				Status: valueToString(row.Status ?? row.status) || 'Available',
+				DataLinkParameter: valueToString(row.DataLinkParameter ?? row.dataLinkParameter),
+				Entries: entries,
+			}
+			const id = valueToString(row.Id ?? row.id).trim()
+			if (id) normalizedRow.Id = id
+			normalizedRows.push(normalizedRow)
+		}
+		return normalizedRows
+	}
+
+	// MEDIALIST V3
+	actions.medialistCreate = {
+		name: 'MEDIALIST | Create',
+		description: 'Creates a new empty Medialist with the documented settings.',
+		options: [
+			{ type: 'textinput', label: 'Name', id: 'name', default: 'New Medialist', useVariables: true },
+			{ type: 'checkbox', label: 'Loop', id: 'isLooped', default: false },
+			{ type: 'checkbox', label: 'Auto Take', id: 'isAutoTake', default: false },
+			{ type: 'checkbox', label: 'Auto Play', id: 'isAutoPlay', default: false },
+			{
+				type: 'number',
+				label: 'Transition Duration',
+				id: 'transitionDuration',
+				default: 0,
+				min: 0,
+				max: 3600,
+			},
+			{ type: 'checkbox', label: 'Generate Thumbnail at Load', id: 'generateThumbnail', default: true },
+			{ type: 'checkbox', label: 'Persistent', id: 'isPersistent', default: true },
+		],
+		callback: async (action) => {
+			const name = await expandOption(self, action.options.name)
+			await sendAndRefresh(self, '/api/v3/medialist', 'POST', {
+				Name: name,
+				Items: [],
+				IsLooped: Boolean(action.options.isLooped),
+				IsAutoTake: Boolean(action.options.isAutoTake),
+				IsAutoPlay: Boolean(action.options.isAutoPlay),
+				TransitionDuration: Number(action.options.transitionDuration),
+				GenerateThumbnailAtLoad: Boolean(action.options.generateThumbnail),
+				IsPersistent: Boolean(action.options.isPersistent),
+			})
+		},
+	}
+
+	actions.medialistPlay = {
+		name: 'MEDIALIST | Selected Medialist - Play',
+		description: 'Plays the currently selected Medialist.',
+		options: [{ type: 'checkbox', label: 'Take to PGM', id: 'take', default: true }],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v3/medialist/selected/play${buildQuery({ take: Boolean(action.options.take) })}`),
+	}
+
+	actions.medialistStop = {
+		name: 'MEDIALIST | Selected Medialist - Stop',
+		description: 'Stops the currently selected Medialist.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v3/medialist/selected/stop', 'POST', true),
+	}
+
+	actions.medialistPause = {
+		name: 'MEDIALIST | Selected Medialist - Pause',
+		description: 'Pauses the currently selected Medialist.',
+		options: [],
+		callback: async () => sendAndRefresh(self, '/api/v3/medialist/selected/pause'),
+	}
+
+	actions.medialistPlayMedia = {
+		name: 'MEDIALIST | Selected Medialist - Select and Play Media',
+		description: 'Selects and plays a media item from the selected Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Media',
+				id: 'mediaId',
+				default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
+			},
+			{ type: 'checkbox', label: 'Play from Beginning', id: 'playFromBeginning', default: true },
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v3/medialist/selected/${encodePathPart(action.options.mediaId)}${buildQuery({
+					playFromBeginning: Boolean(action.options.playFromBeginning),
+				})}`,
+			),
+	}
+
+	actions.medialistPlayMediaByIndex = {
+		name: 'MEDIALIST | Selected Medialist - Select and Play by Index',
+		description: 'Selects and plays a media item from the selected Medialist by zero-based index.',
+		options: [
+			{ type: 'textinput', label: 'Media Index', id: 'mediaIndex', default: '0', useVariables: true },
+			{ type: 'checkbox', label: 'Play from Beginning', id: 'playFromBeginning', default: true },
+		],
+		callback: async (action) => {
+			const mediaIndex = await expandOption(self, action.options.mediaIndex)
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/selected/${encodePathPart(mediaIndex)}${buildQuery({
+					playFromBeginning: Boolean(action.options.playFromBeginning),
+				})}`,
+			)
+		},
+	}
+
+	actions.medialistDeleteMedia = {
+		name: 'MEDIALIST | Selected Medialist - Delete Media',
+		description: 'Deletes a media item from the selected Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Media',
+				id: 'mediaId',
+				default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v3/medialist/selected/${encodePathPart(action.options.mediaId)}`, 'DELETE'),
+	}
+
+	actions.medialistAddMedia = {
+		name: 'MEDIALIST | Selected Medialist - Add Media',
+		description: 'Adds a local media path to the selected Medialist.',
+		options: [
+			{
+				type: 'textinput',
+				label: 'Local Path to Media File',
+				id: 'mediaId',
+				default: '',
+				useVariables: true,
+			},
+		],
+		callback: async (action) => {
+			const path = await expandOption(self, action.options.mediaId)
+			await sendAndRefresh(self, '/api/v3/medialist/selected/media', 'POST', path)
+		},
+	}
+
+	actions.medialistPlayCustom = {
+		name: 'MEDIALIST | Custom Medialist - Play',
+		description: 'Plays a specified Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist',
+				id: 'medialistId',
+				default: self.CHOICES_MEDIALISTS[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+			{ type: 'checkbox', label: 'Take to PGM', id: 'take', default: true },
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(action.options.medialistId)}/play${buildQuery({
+					take: Boolean(action.options.take),
+				})}`,
+			),
+	}
+
+	actions.medialistPlayMediaCustom = {
+		name: 'MEDIALIST | Custom Medialist - Select and Play Media',
+		description: 'Selects and plays a media item in a specified Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+			{ type: 'checkbox', label: 'Play from Beginning', id: 'playFromBeginning', default: true },
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(selected.mediaId)}${buildQuery({
+					playFromBeginning: Boolean(action.options.playFromBeginning),
+				})}`,
+			)
+		},
+	}
+
+	actions.medialistPlayMediaCustomByIndex = {
+		name: 'MEDIALIST | Custom Medialist - Select and Play by Index',
+		description: 'Selects and plays a media item by zero-based index in a specified Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist',
+				id: 'medialistId',
+				default: self.CHOICES_MEDIALISTS[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+			{ type: 'textinput', label: 'Media Index', id: 'mediaIndex', default: '0', useVariables: true },
+			{ type: 'checkbox', label: 'Play from Beginning', id: 'playFromBeginning', default: true },
+		],
+		callback: async (action) => {
+			const mediaIndex = await expandOption(self, action.options.mediaIndex)
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(action.options.medialistId)}/${encodePathPart(mediaIndex)}${buildQuery({
+					playFromBeginning: Boolean(action.options.playFromBeginning),
+				})}`,
+			)
+		},
+	}
+
+	actions.medialistSelectMediaCustom = {
+		name: 'MEDIALIST | Custom Medialist - Select Media',
+		description: 'Selects a media item without starting playback.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(selected.mediaId)}/select`,
+			)
+		},
+	}
+
+	actions.medialistDeleteMediaCustom = {
+		name: 'MEDIALIST | Custom Medialist - Delete Media',
+		description: 'Deletes a selected media item from its Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(selected.mediaId)}`,
+				'DELETE',
+			)
+		},
+	}
+
+	actions.medialistAddMediaCustom = {
+		name: 'MEDIALIST | Custom Medialist - Add Media',
+		description: 'Adds a local media path to a specified Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist',
+				id: 'medialistId',
+				default: self.CHOICES_MEDIALISTS[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+			{ type: 'textinput', label: 'Local Path to Media File', id: 'path', default: '', useVariables: true },
+		],
+		callback: async (action) => {
+			const path = await expandOption(self, action.options.path)
+			await sendAndRefresh(self, `/api/v3/medialist/${encodePathPart(action.options.medialistId)}/media`, 'POST', path)
+		},
+	}
+
+	actions.medialistAddMediaDescription = {
+		name: 'MEDIALIST | Custom Medialist - Add Media Description',
+		description: 'Adds a full media description JSON object at an optional insertion index.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist',
+				id: 'medialistId',
+				default: self.CHOICES_MEDIALISTS[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+			{
+				type: 'textinput',
+				label: 'Insertion Index (blank = end)',
+				id: 'insertionIndex',
+				default: '',
+				useVariables: true,
+			},
+			{
+				type: 'textinput',
+				label: 'Media Description JSON',
+				id: 'description',
+				default: '{"MediaName":"Media","FilePath":"C:\\\\path\\\\file.mp4"}',
+				useVariables: true,
+			},
+		],
+		callback: async (action) => {
+			const payload = await parseJsonOption<Record<string, unknown>>(
+				self,
+				action.options.description,
+				'Media description',
+			)
+			if (!isRecord(payload)) {
+				if (payload !== undefined) self.log('error', 'Media description must be a JSON object')
+				return
+			}
+			const insertionIndex = await expandOption(self, action.options.insertionIndex)
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(action.options.medialistId)}/mediadescription${buildQuery({
+					insertionIndex,
+				})}`,
+				'POST',
+				payload,
+			)
+		},
+	}
+
+	actions.medialistClear = {
+		name: 'MEDIALIST | Custom Medialist - Clear',
+		description: 'Clears all non-live items from the specified Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist',
+				id: 'medialistId',
+				default: self.CHOICES_MEDIALISTS[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, `/api/v3/medialist/${encodePathPart(action.options.medialistId)}/clear`),
+	}
+
+	actions.medialistUpdateMedia = {
+		name: 'MEDIALIST | Update Media Description',
+		description: 'Gets the current media model, merges the JSON fields, then sends the complete PUT payload.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+			{
+				type: 'textinput',
+				label: 'Fields to Merge (JSON)',
+				id: 'patch',
+				default: '{"InPoint":0,"OutPoint":0}',
+				useVariables: true,
+			},
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			const patch = await parseJsonOption<Record<string, unknown>>(self, action.options.patch, 'Media fields')
+			if (!isRecord(patch)) {
+				if (patch !== undefined) self.log('error', 'Media fields must be a JSON object')
+				return
+			}
+			const medialist = await SendCommand(self, `/api/v3/medialist/${encodePathPart(selected.medialistId)}`)
+			const current = Array.isArray(medialist?.Items)
+				? medialist.Items.find((item: any) => String(item?.Id) === selected.mediaId)
+				: undefined
+			if (!isRecord(current)) {
+				self.log('error', 'Unable to retrieve the selected media before update')
+				return
+			}
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(selected.mediaId)}`,
+				'PUT',
+				{ ...current, ...patch, Id: current.Id },
+			)
+		},
+	}
+
+	actions.medialistSetAudioMode = {
+		name: 'MEDIALIST | Set Media Audio Mode',
+		description: 'Sets a media item audio mode.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+			{
+				type: 'dropdown',
+				label: 'Audio Mode',
+				id: 'audioMode',
+				default: 'Mix',
+				choices: [
+					{ id: 'Mix', label: 'Mix' },
+					{ id: 'Mute', label: 'Mute' },
+					{ id: 'Solo', label: 'Solo' },
+				],
+			},
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(
+					selected.mediaId,
+				)}/audiomode${buildQuery({ audioMode: action.options.audioMode })}`,
+				'PUT',
+			)
+		},
+	}
+
+	actions.medialistSetAfterPlay = {
+		name: 'MEDIALIST | Set Media After Play',
+		description: 'Sets a media item after-play behavior.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+			{
+				type: 'dropdown',
+				label: 'After Play',
+				id: 'afterPlay',
+				default: 'Next',
+				choices: [
+					{ id: 'Next', label: 'Next' },
+					{ id: 'Stop', label: 'Stop' },
+					{ id: 'Loop', label: 'Loop' },
+					{ id: 'PauseOnLastFrame', label: 'Pause on Last Frame' },
+				],
+			},
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(
+					selected.mediaId,
+				)}/afterplay${buildQuery({ afterPlay: action.options.afterPlay })}`,
+				'PUT',
+			)
+		},
+	}
+
+	for (const [id, label, suffix] of [
+		['medialistMoveUp', 'Move Up', 'moveup'],
+		['medialistMoveDown', 'Move Down', 'movedown'],
+	] as const) {
+		actions[id] = {
+			name: `MEDIALIST | Selected Medialist - ${label}`,
+			description: `${label}s a media item in the selected Medialist.`,
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Media',
+					id: 'mediaId',
+					default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id ?? 'none',
+					choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
+				},
+			],
+			callback: async (action) =>
+				sendAndRefresh(self, `/api/v3/medialist/selected/${encodePathPart(action.options.mediaId)}/${suffix}`),
+		}
+	}
+
+	actions.medialistMoveToIndex = {
+		name: 'MEDIALIST | Selected Medialist - Move to Index',
+		description: 'Moves a media item to a zero-based position.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Media',
+				id: 'mediaId',
+				default: self.CHOICES_MEDIALIST_SELECTED_MEDIA[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALIST_SELECTED_MEDIA,
+			},
+			{ type: 'textinput', label: 'New Index', id: 'newIndex', default: '0', useVariables: true },
+		],
+		callback: async (action) => {
+			const index = Number(await expandOption(self, action.options.newIndex))
+			if (!Number.isInteger(index) || index < 0) {
+				self.log('error', 'New media index must be a non-negative integer')
+				return
+			}
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/selected/${encodePathPart(action.options.mediaId)}/move`,
+				'POST',
+				index,
+			)
+		},
+	}
+
+	actions.medialistMoveIndexes = {
+		name: 'MEDIALIST | Selected Medialist - Move by Indexes',
+		description: 'Moves an item from an old zero-based index to a new index.',
+		options: [
+			{ type: 'textinput', label: 'Old Index', id: 'oldIndex', default: '0', useVariables: true },
+			{ type: 'textinput', label: 'New Index', id: 'newIndex', default: '0', useVariables: true },
+		],
+		callback: async (action) => {
+			const oldIndex = await expandOption(self, action.options.oldIndex)
+			const newIndex = await expandOption(self, action.options.newIndex)
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/selected/media/move/${encodePathPart(oldIndex)}/${encodePathPart(newIndex)}`,
+			)
+		},
+	}
+
+	for (const [id, label, suffix] of [
+		['medialistMoveUpCustom', 'Move Up', 'moveup'],
+		['medialistMoveDownCustom', 'Move Down', 'movedown'],
+	] as const) {
+		actions[id] = {
+			name: `MEDIALIST | Custom Medialist - ${label}`,
+			description: `${label}s a selected media item in its Medialist.`,
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Medialist - Media',
+					id: 'medialistMedia',
+					default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+					choices: self.CHOICES_MEDIALISTS_MEDIA,
+				},
+			],
+			callback: async (action) => {
+				const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+				if (!selected) return invalidChoice(self, 'Medialist media')
+				await sendAndRefresh(
+					self,
+					`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(selected.mediaId)}/${suffix}`,
+				)
+			},
+		}
+	}
+
+	actions.medialistMoveToIndexCustom = {
+		name: 'MEDIALIST | Custom Medialist - Move to Index',
+		description: 'Moves a media item to a zero-based position in its Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist - Media',
+				id: 'medialistMedia',
+				default: self.CHOICES_MEDIALISTS_MEDIA[0]?.id ?? 'None',
+				choices: self.CHOICES_MEDIALISTS_MEDIA,
+			},
+			{ type: 'textinput', label: 'New Index', id: 'newIndex', default: '0', useVariables: true },
+		],
+		callback: async (action) => {
+			const selected = parseMedialistMediaGlobalChoiceId(valueToString(action.options.medialistMedia))
+			if (!selected) return invalidChoice(self, 'Medialist media')
+			const index = Number(await expandOption(self, action.options.newIndex))
+			if (!Number.isInteger(index) || index < 0) {
+				self.log('error', 'New media index must be a non-negative integer')
+				return
+			}
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(selected.medialistId)}/${encodePathPart(selected.mediaId)}/move`,
+				'POST',
+				index,
+			)
+		},
+	}
+
+	actions.medialistMoveIndexesCustom = {
+		name: 'MEDIALIST | Custom Medialist - Move by Indexes',
+		description: 'Moves an item between zero-based indexes in a specified Medialist.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Medialist',
+				id: 'medialistId',
+				default: self.CHOICES_MEDIALISTS[0]?.id ?? 'none',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+			{ type: 'textinput', label: 'Old Index', id: 'oldIndex', default: '0', useVariables: true },
+			{ type: 'textinput', label: 'New Index', id: 'newIndex', default: '0', useVariables: true },
+		],
+		callback: async (action) => {
+			const oldIndex = await expandOption(self, action.options.oldIndex)
+			const newIndex = await expandOption(self, action.options.newIndex)
+			await sendAndRefresh(
+				self,
+				`/api/v3/medialist/${encodePathPart(action.options.medialistId)}/media/move/${encodePathPart(
+					oldIndex,
+				)}/${encodePathPart(newIndex)}`,
+			)
+		},
+	}
+
+	// TITLER V2
+	actions.titlerElementVisible = {
+		name: 'TITLER | Set Element Visible/Invisible',
+		description: 'Takes a Titler element on or off.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Element',
+				id: 'elementId',
+				default: self.CHOICES_TITLER_ELEMENTS[0]?.id ?? 'none',
+				choices: self.CHOICES_TITLER_ELEMENTS,
+			},
+			{ type: 'checkbox', label: 'Is On', id: 'isOn', default: true },
+			{ type: 'checkbox', label: 'Use Animation', id: 'isAnimate', default: true },
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/titler/selected/elements/${encodePathPart(action.options.elementId)}/visible${buildQuery({
+					isOn: Boolean(action.options.isOn),
+					isAnimated: Boolean(action.options.isAnimate),
+				})}`,
+			),
+	}
+
+	actions.titlerSetSocialMediaData = {
+		name: 'TITLER | Set Social Media Data',
+		description: 'Sets the social media data payload for the selected Titler file.',
+		options: [
+			{ type: 'textinput', label: 'Username', id: 'username', default: '', useVariables: true },
+			{ type: 'textinput', label: 'Date', id: 'date', default: '', useVariables: true },
+			{ type: 'textinput', label: 'Content', id: 'content', default: '', useVariables: true },
+			{ type: 'textinput', label: 'Logo', id: 'logo', default: '', useVariables: true },
+			{ type: 'textinput', label: 'Avatar', id: 'avatar', default: '', useVariables: true },
+			{ type: 'textinput', label: 'Attachment', id: 'attachment', default: '', useVariables: true },
+		],
+		callback: async (action) =>
+			sendAndRefresh(self, '/api/v2/titler/selected/elements/socialmedia/data', 'PUT', {
+				Username: await expandOption(self, action.options.username),
+				Date: await expandOption(self, action.options.date),
+				Content: await expandOption(self, action.options.content),
+				Logo: await expandOption(self, action.options.logo),
+				Avatar: await expandOption(self, action.options.avatar),
+				Attachment: await expandOption(self, action.options.attachment),
+			}),
+	}
+
+	for (const kind of ['speaker', 'panel'] as const) {
+		const title = kind === 'speaker' ? 'Speaker' : 'Panel'
+		const rowChoices =
+			kind === 'speaker' ? self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS : self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS
+		const elementChoices =
+			kind === 'speaker' ? self.CHOICES_TITLER_SPEAKER_ELEMENTS : self.CHOICES_TITLER_PANEL_ELEMENTS
+
+		actions[`titlerSet${title}EntryLiveRow`] = {
+			name: `TITLER | Set ${title} Row Live`,
+			description: `Sets a ${title.toLowerCase()} row live.`,
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Element - Row',
+					id: 'rowId',
+					default: rowChoices[0]?.id ?? 'none',
+					choices: rowChoices,
+				},
+				{ type: 'checkbox', label: 'Reset Auto-Off Timer', id: 'resetTimer', default: true },
+			],
+			callback: async (action) => {
+				const parts = parseTitlerRowChoice(action.options.rowId, kind)
+				if (!parts) return invalidChoice(self, `${title} row`)
+				await sendAndRefresh(
+					self,
+					`/api/v2/titler/selected/elements/${encodePathPart(parts[0])}/${kind}/entries/${encodePathPart(
+						parts[1],
+					)}/live${buildQuery({ resetAutoOffTimer: Boolean(action.options.resetTimer) })}`,
+				)
+			},
+		}
+
+		actions[`titlerClear${title}LiveRow`] = {
+			name: `TITLER | Clear ${title} Live Row`,
+			description: `Clears the live row of a ${title.toLowerCase()} element.`,
+			options: [
+				{
+					type: 'dropdown',
+					label: `${title} Element`,
+					id: 'elementId',
+					default: elementChoices[0]?.id ?? 'none',
+					choices: elementChoices,
+				},
+			],
+			callback: async (action) =>
+				sendAndRefresh(
+					self,
+					`/api/v2/titler/selected/elements/${encodePathPart(action.options.elementId)}/${kind}/entries/live/clear`,
+				),
+		}
+
+		actions[`titlerUpdate${title}Row`] = {
+			name: `TITLER | Update ${title} Row`,
+			description:
+				kind === 'panel'
+					? 'Loads the selected Panel row values automatically, then sends the complete PUT payload.'
+					: `Gets the selected ${title.toLowerCase()} row, merges its entry values, then sends the complete PUT payload.`,
+			options:
+				kind === 'panel'
+					? buildPanelUpdateRowOptions(rowChoices)
+					: [
+							{
+								type: 'dropdown',
+								label: 'Element - Row',
+								id: 'rowId',
+								default: rowChoices[0]?.id ?? 'none',
+								choices: rowChoices,
+							},
+							{
+								type: 'textinput',
+								label: 'Entries to Merge (JSON object)',
+								id: 'entries',
+								default: '{}',
+								useVariables: true,
+							},
+							{ type: 'checkbox', label: 'Replace All Entries', id: 'replaceEntries', default: false },
+							{
+								type: 'textinput',
+								label: 'Data Link Parameter (blank keeps current)',
+								id: 'dataLinkParameter',
+								default: '',
+								useVariables: true,
+							},
+							{ type: 'checkbox', label: 'Reset Auto-Off Timer', id: 'resetTimer', default: true },
+						],
+			callback: async (action) => {
+				const parts = parseTitlerRowChoice(action.options.rowId, kind)
+				if (!parts) return invalidChoice(self, `${title} row`)
+				const endpoint = `/api/v2/titler/selected/elements/${encodePathPart(parts[0])}/${kind}/entries/${encodePathPart(parts[1])}`
+				const current = await SendCommand(self, endpoint)
+				if (!isRecord(current)) {
+					self.log('error', `Unable to retrieve ${title.toLowerCase()} row before update`)
+					return
+				}
+
+				let entries: Record<string, string>
+				let dataLinkParameter: string
+				if (kind === 'panel') {
+					const columns = getTitlerColumnDefinitions(getTitlerStructure(parts[0], kind))
+					entries = {}
+					for (const [columnIndex, column] of columns.entries()) {
+						const optionId = makeTitlerRowColumnOptionId(kind, parts[0], parts[1], column.name, columnIndex)
+						const currentValue = valueToString(current.Entries?.[column.name])
+						entries[column.name] = Object.prototype.hasOwnProperty.call(action.options, optionId)
+							? await expandOption(self, action.options[optionId])
+							: currentValue
+					}
+
+					const advancedValue = valueToString(action.options.entries).trim()
+					if (advancedValue) {
+						const advancedEntries = await parseEntries(advancedValue)
+						if (!advancedEntries) return
+						Object.assign(entries, advancedEntries)
+					}
+					const dataLinkOptionId = makeTitlerRowDataLinkOptionId(kind, parts[0], parts[1])
+					const legacyDataLink = await expandOption(self, action.options.dataLinkParameter)
+					dataLinkParameter = Object.prototype.hasOwnProperty.call(action.options, dataLinkOptionId)
+						? await expandOption(self, action.options[dataLinkOptionId])
+						: legacyDataLink || valueToString(current.DataLinkParameter)
+				} else {
+					const parsedEntries = await parseEntries(action.options.entries)
+					if (!parsedEntries) return
+					entries = parsedEntries
+					dataLinkParameter = await expandOption(self, action.options.dataLinkParameter)
+				}
+
+				const payload: Record<string, any> = {
+					...current,
+					Id: valueToString(current.Id).trim() || parts[1],
+					Entries: action.options.replaceEntries ? entries : { ...(current.Entries ?? {}), ...entries },
+				}
+				if (kind === 'panel' || dataLinkParameter) payload.DataLinkParameter = dataLinkParameter
+				await sendAndRefresh(
+					self,
+					`${endpoint}${buildQuery({ resetAutoOffTimer: Boolean(action.options.resetTimer) })}`,
+					'PUT',
+					payload,
+				)
+			},
+		}
+
+		actions[`titlerDelete${title}Row`] = {
+			name: `TITLER | Delete ${title} Row`,
+			description: `Deletes the selected ${title.toLowerCase()} row.`,
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Element - Row',
+					id: 'rowId',
+					default: rowChoices[0]?.id ?? 'none',
+					choices: rowChoices,
+				},
+			],
+			callback: async (action) => {
+				const parts = parseTitlerRowChoice(action.options.rowId, kind)
+				if (!parts) return invalidChoice(self, `${title} row`)
+				await sendAndRefresh(
+					self,
+					`/api/v2/titler/selected/elements/${encodePathPart(parts[0])}/${kind}/entries/${encodePathPart(parts[1])}`,
+					'DELETE',
+				)
+			},
+		}
+
+		actions[`titlerAdd${title}Entry`] = {
+			name: `TITLER | Add ${title} Entry`,
+			description:
+				kind === 'panel'
+					? 'Adds a Panel row and builds its Entries object automatically from the selected element structure.'
+					: 'Adds a row to a speaker element. Available column names are fetched from its structure.',
+			options:
+				kind === 'panel'
+					? buildPanelEntryOptions()
+					: [
+							{
+								type: 'dropdown',
+								label: `${title} Element`,
+								id: 'elementId',
+								default: elementChoices[0]?.id ?? 'none',
+								choices: elementChoices,
+							},
+							{
+								type: 'textinput',
+								label: 'Entries (JSON object)',
+								id: 'entries',
+								default: '{}',
+								useVariables: true,
+							},
+							{
+								type: 'textinput',
+								label: 'Data Link Parameter',
+								id: 'dataLinkParameter',
+								default: '',
+								useVariables: true,
+							},
+						],
+			callback: async (action) => {
+				const elementId = valueToString(action.options.elementId)
+				let entries: Record<string, string>
+
+				if (kind === 'panel') {
+					let structure = getTitlerStructure(elementId, kind)
+					let columns = getTitlerColumnDefinitions(structure)
+					if (columns.length === 0) {
+						const fetchedStructure = await SendCommand(
+							self,
+							`/api/v2/titler/selected/elements/${encodePathPart(elementId)}/${kind}/structure`,
+						)
+						if (isRecord(fetchedStructure)) {
+							self.TITLER_ELEMENT_STRUCTURES[`${elementId}:${kind}`] = fetchedStructure
+							structure = fetchedStructure
+							columns = getTitlerColumnDefinitions(structure)
+							self.updateActions()
+						}
+					}
+
+					entries = {}
+					for (const [columnIndex, column] of columns.entries()) {
+						const optionId = makeTitlerColumnOptionId(kind, elementId, column.name, columnIndex)
+						entries[column.name] = await expandOption(self, action.options[optionId] ?? '')
+					}
+
+					const advancedValue = valueToString(action.options.entries).trim()
+					if (advancedValue) {
+						const advancedEntries = await parseEntries(advancedValue)
+						if (!advancedEntries) return
+						Object.assign(entries, advancedEntries)
+					}
+
+					const dataLinkParameter = await expandOption(self, action.options.dataLinkParameter)
+					if (Object.keys(entries).length === 0 && !dataLinkParameter) {
+						self.log(
+							'error',
+							'No Panel columns are available. Start Titler, select a file containing this Panel, and wait for the module refresh.',
+						)
+						return
+					}
+				} else {
+					const parsedEntries = await parseEntries(action.options.entries)
+					if (!parsedEntries) return
+					entries = parsedEntries
+				}
+
+				await sendAndRefresh(
+					self,
+					`/api/v2/titler/selected/elements/${encodePathPart(elementId)}/${kind}/entries`,
+					'POST',
+					{
+						Status: 'Available',
+						DataLinkParameter: await expandOption(self, action.options.dataLinkParameter),
+						Entries: entries,
+					},
+				)
+			},
+		}
+
+		actions[`titlerUpdateAll${title}Entries`] = {
+			name: `TITLER | Update All ${title} Entries`,
+			description:
+				kind === 'panel'
+					? 'Loads every existing Panel row and column automatically, then sends the complete PUT payload.'
+					: `Replaces all rows of a ${title.toLowerCase()} element with a documented JSON array.`,
+			options:
+				kind === 'panel'
+					? buildPanelUpdateAllOptions()
+					: [
+							{
+								type: 'dropdown',
+								label: `${title} Element`,
+								id: 'elementId',
+								default: elementChoices[0]?.id ?? 'none',
+								choices: elementChoices,
+							},
+							{
+								type: 'textinput',
+								label: 'Rows (JSON array)',
+								id: 'rows',
+								default: '[]',
+								useVariables: true,
+							},
+							{ type: 'checkbox', label: 'Reset Auto-Off Timer', id: 'resetTimer', default: true },
+						],
+			callback: async (action) => {
+				const elementId = valueToString(action.options.elementId)
+				let rows: unknown[]
+
+				if (kind === 'panel') {
+					let columns = getTitlerColumnDefinitions(getTitlerStructure(elementId, kind))
+					if (columns.length === 0) {
+						const fetchedStructure = await SendCommand(
+							self,
+							`/api/v2/titler/selected/elements/${encodePathPart(elementId)}/${kind}/structure`,
+						)
+						if (isRecord(fetchedStructure)) {
+							self.TITLER_ELEMENT_STRUCTURES[`${elementId}:${kind}`] = fetchedStructure
+							columns = getTitlerColumnDefinitions(fetchedStructure)
+							self.updateActions()
+						}
+					}
+					if (columns.length === 0) {
+						self.log(
+							'error',
+							'Unable to load the Panel column definitions. Start Titler, select the file, and try again.',
+						)
+						return
+					}
+
+					const fetchedRows = await SendCommand(
+						self,
+						`/api/v2/titler/selected/elements/${encodePathPart(elementId)}/${kind}/entries`,
+					)
+					const currentRows = Array.isArray(fetchedRows) ? fetchedRows : getTitlerRows(elementId, kind)
+					const generatedRows: Record<string, unknown>[] = []
+					for (const row of currentRows) {
+						if (!isRecord(row)) continue
+						const rowId = valueToString(row.Id).trim()
+						const entries: Record<string, string> = {}
+						for (const [columnIndex, column] of columns.entries()) {
+							const optionId = makeTitlerRowColumnOptionId(kind, elementId, rowId, column.name, columnIndex)
+							const currentValue = valueToString(row.Entries?.[column.name])
+							const enteredValue = Object.prototype.hasOwnProperty.call(action.options, optionId)
+								? await expandOption(self, action.options[optionId])
+								: ''
+							entries[column.name] = enteredValue.trim() ? enteredValue : currentValue
+						}
+
+						const dataLinkOptionId = makeTitlerRowDataLinkOptionId(kind, elementId, rowId)
+						const enteredDataLink = Object.prototype.hasOwnProperty.call(action.options, dataLinkOptionId)
+							? await expandOption(self, action.options[dataLinkOptionId])
+							: ''
+						const dataLinkParameter = enteredDataLink.trim() ? enteredDataLink : valueToString(row.DataLinkParameter)
+						const generatedRow: Record<string, unknown> = {
+							Status: valueToString(row.Status) || 'Available',
+							DataLinkParameter: dataLinkParameter,
+							Entries: entries,
+						}
+						if (rowId) generatedRow.Id = rowId
+						generatedRows.push(generatedRow)
+					}
+
+					const rawRows = valueToString(action.options.rows).trim()
+					const useAdvancedRows = Boolean(action.options.showAdvancedRows) || (rawRows.length > 0 && rawRows !== '[]')
+					if (useAdvancedRows) {
+						const parsedRows = await parseJsonOption<unknown>(self, action.options.rows, `${title} rows`)
+						const normalizedRows = normalizePanelRows(parsedRows)
+						if (!normalizedRows) return
+						rows = normalizedRows
+					} else {
+						if (generatedRows.length === 0) {
+							self.log('error', 'This Panel has no existing rows. Use Add Panel Entry first.')
+							return
+						}
+						rows = generatedRows
+					}
+				} else {
+					const parsedRows = await parseJsonOption<unknown>(self, action.options.rows, `${title} rows`)
+					if (!Array.isArray(parsedRows)) {
+						if (parsedRows !== undefined) self.log('error', `${title} rows must be a JSON array`)
+						return
+					}
+					rows = parsedRows
+				}
+
+				await sendAndRefresh(
+					self,
+					`/api/v2/titler/selected/elements/${encodePathPart(elementId)}/${kind}/entries${buildQuery({
+						resetAutoOffTimer: Boolean(action.options.resetTimer),
+					})}`,
+					'PUT',
+					rows,
+				)
+			},
+		}
+	}
+
+	actions.titlerSetTickerContent = {
+		name: 'TITLER | Set Ticker Content',
+		description: 'Sets the content of a Ticker element.',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Ticker Element',
+				id: 'elementId',
+				default: self.CHOICES_TITLER_TICKER_ELEMENTS[0]?.id ?? 'none',
+				choices: self.CHOICES_TITLER_TICKER_ELEMENTS,
+			},
+			{ type: 'textinput', label: 'Content', id: 'content', default: '', useVariables: true },
+		],
+		callback: async (action) =>
+			sendAndRefresh(
+				self,
+				`/api/v2/titler/selected/elements/${encodePathPart(action.options.elementId)}/ticker/content`,
+				'POST',
+				{ Content: await expandOption(self, action.options.content) },
+			),
 	}
 
 	self.setActionDefinitions(actions)

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,8 @@ import type { MulticamInstance } from './main.js'
 import { startPolling, stopPolling } from './polling.js'
 import { InitSignalR } from './signalr.js'
 
-export async function InitConnection(self: MulticamInstance): Promise<void> {
+export async function InitConnection(self: MulticamInstance, isCurrent: () => boolean = () => true): Promise<void> {
+	if (!isCurrent()) return
 	self.updateStatus(InstanceStatus.Connecting, 'Connecting...')
 
 	if (self.config.host && self.config.port) {
@@ -14,23 +15,25 @@ export async function InitConnection(self: MulticamInstance): Promise<void> {
 				SendCommand(self, cmd),
 				timeout(2000), // 2 second timeout
 			])
+			if (!isCurrent()) return
 
 			if (!results) {
 				self.updateStatus(InstanceStatus.ConnectionFailure, 'No response from Multicam')
-				stopPolling()
+				stopPolling(self)
 				return
 			}
 
 			self.updateStatus(InstanceStatus.Ok)
 			self.log('info', 'Connected successfully')
 			startPolling(self)
-			InitSignalR(self)
+			await InitSignalR(self)
 		} catch (error: any) {
+			if (!isCurrent()) return
 			self.log('error', `Connection failed: ${error.message || error}`)
 			self.updateStatus(InstanceStatus.ConnectionFailure, 'Failed to connect - check IP')
-			stopPolling()
+			stopPolling(self)
 		}
-	} else {
+	} else if (isCurrent()) {
 		self.updateStatus(InstanceStatus.BadConfig, 'Missing host or port')
 	}
 }
@@ -39,11 +42,42 @@ async function timeout(ms: number): Promise<never> {
 	return new Promise((_, reject) => setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms))
 }
 
+function formatApiError(result: unknown, statusText: string): string {
+	if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+		if (typeof result === 'string') return result
+		if (typeof result === 'number' || typeof result === 'boolean' || typeof result === 'bigint') return `${result}`
+		return statusText
+	}
+
+	const response = result as Record<string, unknown>
+	const errors = response.errors
+	if (typeof errors === 'object' && errors !== null && !Array.isArray(errors)) {
+		const messages = Object.entries(errors as Record<string, unknown>).flatMap(([field, value]) => {
+			const fieldMessages = Array.isArray(value) ? value : [value]
+			return fieldMessages.map((message) => {
+				if (typeof message === 'string') return `${field}: ${message}`
+				if (typeof message === 'number' || typeof message === 'boolean' || typeof message === 'bigint') {
+					return `${field}: ${message}`
+				}
+				return `${field}: ${JSON.stringify(message)}`
+			})
+		})
+		if (messages.length > 0) {
+			const title = typeof response.title === 'string' ? `${response.title} ` : ''
+			return `${title}${messages.join('; ')}`
+		}
+	}
+
+	if (typeof response.detail === 'string') return response.detail
+	if (typeof response.title === 'string') return response.title
+	return JSON.stringify(response)
+}
+
 export async function SendCommand(
 	self: MulticamInstance,
 	cmd: string,
 	method: string = 'GET',
-	payload: any = undefined,
+	payload: unknown = undefined,
 ): Promise<any> {
 	try {
 		if (self.config.host && self.config.port) {
@@ -58,9 +92,9 @@ export async function SendCommand(
 			}
 
 			//if api key is specified, add it to headers
-			if (self.config.specifyApiKey == true && self.config.apiKey) {
-				self.log('debug', `Using API Key: ${self.config.apiKey}`)
-				headers['x-apikey'] = `${self.config.apiKey}`
+			if (self.config.specifyApiKey == true && self.secrets.apiKey) {
+				self.log('debug', 'Using configured API Key')
+				headers['x-apikey'] = self.secrets.apiKey
 			} else {
 				self.log(
 					'debug',
@@ -70,9 +104,8 @@ export async function SendCommand(
 
 			let body: string | undefined = undefined
 
-			// If payload is provided, include it in the request
-			if (payload) {
-				method = 'POST' //override to POST if we have a payload
+			// If payload is provided, include it in the request without changing the requested HTTP method.
+			if (payload !== undefined) {
 				body = JSON.stringify(payload)
 			}
 
@@ -83,14 +116,24 @@ export async function SendCommand(
 			})
 
 			const contentType = response.headers.get('content-type') || ''
-
 			const raw = await response.text()
+			let result: any
 
-			if (contentType.includes('application/json')) {
-				return JSON.parse(raw)
+			if (!raw) {
+				result = undefined
+			} else if (contentType.includes('application/json') || contentType.includes('application/problem+json')) {
+				result = JSON.parse(raw)
 			} else {
-				return raw.trim()
+				result = raw.trim()
 			}
+
+			if (!response.ok) {
+				const detail = formatApiError(result, response.statusText)
+				self.log('warn', `${method} ${cmd} failed (${response.status}): ${detail}`)
+				return undefined
+			}
+
+			return result
 		} else {
 			self.log('error', 'Invalid host or port configuration')
 			return undefined

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,43 +3,74 @@ import type { MulticamInstance } from './main.js'
 import { startPolling, stopPolling } from './polling.js'
 import { InitSignalR } from './signalr.js'
 
-export async function InitConnection(self: MulticamInstance, isCurrent: () => boolean = () => true): Promise<void> {
-	if (!isCurrent()) return
+const CONNECTION_PROBE_TIMEOUT_MS = 2000
+
+/**
+ * Lightweight health check used by both the initial connection and the reconnect supervisor.
+ * It intentionally doesn't log failures: while Multicam is offline, the supervisor owns the
+ * status and retry messages and avoids filling Companion's log on every probe.
+ */
+export async function ProbeConnection(
+	self: MulticamInstance,
+	timeoutMs: number = CONNECTION_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+	if (!self.config.host || !self.config.port) return false
+
+	const controller = new AbortController()
+	const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+	const headers: Record<string, string> = {
+		Accept: 'application/json',
+	}
+	if (self.config.specifyApiKey && self.secrets.apiKey) {
+		headers['x-apikey'] = self.secrets.apiKey
+	}
+
+	try {
+		const response = await fetch(`http://${self.config.host}:${self.config.port}/api/application/version`, {
+			method: 'GET',
+			headers,
+			signal: controller.signal,
+		})
+		await response.text()
+		return response.ok
+	} catch (_error) {
+		return false
+	} finally {
+		clearTimeout(timeoutId)
+	}
+}
+
+export async function InitConnection(self: MulticamInstance, isCurrent: () => boolean = () => true): Promise<boolean> {
+	if (!isCurrent()) return false
 	self.updateStatus(InstanceStatus.Connecting, 'Connecting...')
 
 	if (self.config.host && self.config.port) {
-		const cmd = `/api/application/version`
-
 		try {
-			const results = await Promise.race([
-				SendCommand(self, cmd),
-				timeout(2000), // 2 second timeout
-			])
-			if (!isCurrent()) return
+			const connected = await ProbeConnection(self)
+			if (!isCurrent()) return false
 
-			if (!results) {
+			if (!connected) {
 				self.updateStatus(InstanceStatus.ConnectionFailure, 'No response from Multicam')
 				stopPolling(self)
-				return
+				return false
 			}
 
 			self.updateStatus(InstanceStatus.Ok)
 			self.log('info', 'Connected successfully')
 			startPolling(self)
 			await InitSignalR(self)
+			return true
 		} catch (error: any) {
-			if (!isCurrent()) return
+			if (!isCurrent()) return false
 			self.log('error', `Connection failed: ${error.message || error}`)
 			self.updateStatus(InstanceStatus.ConnectionFailure, 'Failed to connect - check IP')
 			stopPolling(self)
+			return false
 		}
 	} else if (isCurrent()) {
 		self.updateStatus(InstanceStatus.BadConfig, 'Missing host or port')
 	}
-}
-
-async function timeout(ms: number): Promise<never> {
-	return new Promise((_, reject) => setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms))
+	return false
 }
 
 function formatApiError(result: unknown, statusText: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,17 @@
-import type { SomeCompanionConfigField } from '@companion-module/base'
+import type { JsonObject, SomeCompanionConfigField } from '@companion-module/base'
 import { Regex } from '@companion-module/base'
 
-export interface ModuleConfig {
+export interface ModuleConfig extends JsonObject {
 	host: string
 	port: number
 	specifyApiKey: boolean
-	apiKey: string
 	enablePolling: boolean
 	pollingInterval: number
 	verbose: boolean
+}
+
+export interface ModuleSecrets extends JsonObject {
+	apiKey: string
 }
 
 export function GetConfigFields(): SomeCompanionConfigField[] {
@@ -57,14 +60,15 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			label: 'Specify API Key',
 			default: false,
 			width: 4,
+			disableAutoExpression: true,
 		},
 		{
-			type: 'textinput',
+			type: 'secret-text',
 			id: 'apiKey',
 			label: 'API Key',
 			width: 8,
 			default: '',
-			isVisible: (config) => !!config.specifyApiKey,
+			isVisibleExpression: '$(options:specifyApiKey)',
 		},
 		{
 			type: 'static-text',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-module.exports = {}
+export {}

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -1,12 +1,144 @@
-import { CompanionFeedbackDefinitions, combineRgb } from '@companion-module/base'
+import { combineRgb } from '@companion-module/base'
+import type { CompanionFeedbackDefinitions, CompanionOptionValues } from '@companion-module/base'
 import type { MulticamInstance } from './main.js'
+
+export type FeedbacksSchema = Record<string, { type: 'boolean'; options: CompanionOptionValues }>
+
+function optionValueToString(value: unknown): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return `${value}`
+	return ''
+}
 
 export function UpdateFeedbacks(self: MulticamInstance): void {
 	const COLOR_WHITE = combineRgb(255, 255, 255)
 	const COLOR_GREEN = combineRgb(0, 255, 0)
 	const COLOR_RED = combineRgb(255, 0, 0)
 
-	const feedbacks: CompanionFeedbackDefinitions = {}
+	const feedbacks: CompanionFeedbackDefinitions<FeedbacksSchema> = {}
+
+	//APPLICATION
+	feedbacks.applicationAutoMode = {
+		type: 'boolean',
+		name: 'APPLICATION | Auto/Manual mode matches',
+		description: 'Changes color when the application is in the selected automation mode.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'mode',
+				label: 'Mode',
+				default: 'Auto',
+				choices: [
+					{ id: 'Auto', label: 'Auto' },
+					{ id: 'Manual', label: 'Manual' },
+				],
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => self.getVariableValue('applicationAutoState') === feedback.options.mode,
+	}
+
+	feedbacks.signalrConnected = {
+		type: 'boolean',
+		name: 'SIGNALR | Hub is connected',
+		description: 'Changes color while the AssistHub SignalR connection is active.',
+		options: [],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: () => self.SIGNALR_CONNECTED,
+	}
+
+	//AUDIO
+	feedbacks.audioSelectedProfile = {
+		type: 'boolean',
+		name: 'AUDIO | Profile is selected',
+		description: 'Changes color when the chosen mixer profile is selected.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'profileId',
+				label: 'Profile',
+				default: self.CHOICES_AUDIO_PROFILES[0]?.id || '',
+				choices: self.CHOICES_AUDIO_PROFILES,
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => String(self.AUDIO_PROFILE_SELECTED?.Id ?? '') === feedback.options.profileId,
+	}
+
+	//CONF
+	feedbacks.confAutomationMode = {
+		type: 'boolean',
+		name: 'CONF | Automation mode matches',
+		description: 'Changes color when Conf is in the selected automation mode.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'mode',
+				label: 'Mode',
+				default: 'Auto',
+				choices: [
+					{ id: 'Auto', label: 'Auto' },
+					{ id: 'Wide', label: 'Wide' },
+					{ id: 'Man', label: 'Manual' },
+				],
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => self.CONF_STATE?.microphones?.AutomationMode === feedback.options.mode,
+	}
+
+	//INSITU
+	feedbacks.insituTagActive = {
+		type: 'boolean',
+		name: 'INSITU | Tag is active',
+		description: 'Changes color when an Insitu tag is active.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'tag',
+				label: 'Tag',
+				default: self.CHOICES_INSITU_TAGS[0]?.id || '',
+				choices: self.CHOICES_INSITU_TAGS,
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => self.INSITU_ACTIVE_TAGS.some((tag) => tag?.Name === feedback.options.tag),
+	}
+
+	feedbacks.insituLayoutActive = {
+		type: 'boolean',
+		name: 'INSITU | Layout is active',
+		description: 'Changes color when an Insitu layout is active.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'layout',
+				label: 'Layout',
+				default: self.CHOICES_INSITU_LAYOUTS[0]?.id || '',
+				choices: self.CHOICES_INSITU_LAYOUTS,
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => self.INSITU_ACTIVE_LAYOUT?.Name === feedback.options.layout,
+	}
+
+	//MEDIALIST
+	feedbacks.medialistSelected = {
+		type: 'boolean',
+		name: 'MEDIALIST | Medialist is selected',
+		description: 'Changes color when the selected Medialist matches.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'medialistId',
+				label: 'Medialist',
+				default: self.CHOICES_MEDIALISTS[0]?.id || '',
+				choices: self.CHOICES_MEDIALISTS,
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => String(self.MEDIALIST_SELECTED?.Id ?? '') === feedback.options.medialistId,
+	}
 
 	//COMPOSER
 	//file is the currently selected file
@@ -196,7 +328,7 @@ export function UpdateFeedbacks(self: MulticamInstance): void {
 			bgcolor: COLOR_GREEN,
 		},
 		callback: (feedback) => {
-			const id: string = String(feedback.options.titlerElementRowId)
+			const id = optionValueToString(feedback.options.titlerElementRowId)
 			const elementId = id.split('_speaker_')[0]
 			const rowId = id.split('_speaker_')[1]
 
@@ -229,7 +361,7 @@ export function UpdateFeedbacks(self: MulticamInstance): void {
 			bgcolor: COLOR_GREEN,
 		},
 		callback: (feedback) => {
-			const id: string = String(feedback.options.titlerElementRowId)
+			const id = optionValueToString(feedback.options.titlerElementRowId)
 			const elementId = id.split('_panel_')[0]
 			const rowId = id.split('_panel_')[1]
 
@@ -257,6 +389,37 @@ export function UpdateFeedbacks(self: MulticamInstance): void {
 		},
 	}
 
+	feedbacks.recordingPaused = {
+		type: 'boolean',
+		name: 'RECORDING | Recording is paused',
+		description: 'Changes color while the active recording is paused.',
+		options: [],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_RED },
+		callback: () => self.RECORDING_PAUSED,
+	}
+
+	//RADIO
+	feedbacks.radioAutomationMode = {
+		type: 'boolean',
+		name: 'RADIO | Automation mode matches',
+		description: 'Changes color when Radio is in the selected automation mode.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'mode',
+				label: 'Mode',
+				default: 'Auto',
+				choices: [
+					{ id: 'Auto', label: 'Auto' },
+					{ id: 'Wide', label: 'Wide' },
+					{ id: 'Man', label: 'Manual' },
+				],
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => self.RADIO_STATE?.microphones?.AutomationMode === feedback.options.mode,
+	}
+
 	//streaming
 	feedbacks.streaming = {
 		type: 'boolean',
@@ -278,6 +441,24 @@ export function UpdateFeedbacks(self: MulticamInstance): void {
 		callback: (feedback) => {
 			return self.ACTIVE_STREAMS.some((p) => p.id === feedback.options.streamingProfileId)
 		},
+	}
+
+	//VIDEO
+	feedbacks.videoLiveSource = {
+		type: 'boolean',
+		name: 'VIDEO | Source is live',
+		description: 'Changes color when the selected video source is live.',
+		options: [
+			{
+				type: 'dropdown',
+				id: 'source',
+				label: 'Source',
+				default: self.CHOICES_VIDEO_SOURCES[0]?.id || '',
+				choices: self.CHOICES_VIDEO_SOURCES,
+			},
+		],
+		defaultStyle: { color: COLOR_WHITE, bgcolor: COLOR_GREEN },
+		callback: (feedback) => self.VIDEO_LIVE_SOURCE === feedback.options.source,
 	}
 	self.setFeedbackDefinitions(feedbacks)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
-import { InstanceBase, runEntrypoint, type SomeCompanionConfigField } from '@companion-module/base'
-import { GetConfigFields, type ModuleConfig } from './config.js'
+import { InstanceBase, type SomeCompanionConfigField } from '@companion-module/base'
+import { GetConfigFields, type ModuleConfig, type ModuleSecrets } from './config.js'
 import { UpgradeScripts } from './upgrades.js'
-import { UpdateActions } from './actions.js'
-import { UpdateFeedbacks } from './feedbacks.js'
-import { UpdateVariableDefinitions } from './variables.js'
+import { UpdateActions, type ActionsSchema } from './actions.js'
+import { UpdateFeedbacks, type FeedbacksSchema } from './feedbacks.js'
+import { UpdatePresets } from './presets.js'
+import { UpdateVariableDefinitions, type VariablesSchema } from './variables.js'
 import { InitConnection } from './api.js'
 import type * as signalR from '@microsoft/signalr'
+import { stopPolling } from './polling.js'
 
 export interface StreamingProfile {
 	id: string
@@ -18,16 +20,60 @@ export interface StreamingProfile {
 	errorMessage: string
 }
 
-export class MulticamInstance extends InstanceBase<ModuleConfig> {
+export interface DropdownChoice {
+	id: string
+	label: string
+}
+
+export type ModuleSchema = {
+	config: ModuleConfig
+	secrets: ModuleSecrets
+	actions: ActionsSchema
+	feedbacks: FeedbacksSchema
+	variables: VariablesSchema
+}
+
+export { UpgradeScripts }
+
+export class MulticamInstance extends InstanceBase<ModuleSchema> {
 	config!: ModuleConfig // Setup in init()
-	CHOICES_APPLICATIONS: { id: string; label: string }[]
+	secrets: ModuleSecrets = { apiKey: '' }
+	CHOICES_APPLICATIONS: DropdownChoice[]
 	APPLICATIONS: any[] = [] //list of licensed applications
+	APPLICATION_TEMPLATES: Record<string, any[]> = {}
+	CHOICES_APPLICATION_TEMPLATES: DropdownChoice[] = []
+	RUNNING_APPLICATION: string = ''
 	ROOMS: any[] = [] //list of rooms
-	CHOICES_ROOMS: { id: string; label: string }[] = [] //choices for rooms
+	CHOICES_ROOMS: DropdownChoice[] = [] //choices for rooms
 	ROOM_SELECTED: any = {} //currently selected room
 	AUDIO_PROFILES: any[] = [] //list of audio profiles
 	AUDIO_PROFILE_SELECTED: any = {} //currently selected audio profile
-	CHOICES_AUDIO_PROFILES: { id: string; label: string }[] = [] //choices for audio profiles
+	CHOICES_AUDIO_PROFILES: DropdownChoice[] = [] //choices for audio profiles
+
+	//CAMERA / PILOT / STUDIO
+	CHOICES_CAMERA_SOURCES: DropdownChoice[] = []
+	CHOICES_CAMERA_INDEXES: DropdownChoice[] = []
+	PILOT_SEQUENCES: any[] = []
+	CHOICES_PILOT_SEQUENCES: DropdownChoice[] = []
+	STUDIO_PRESETS: any[] = []
+	CHOICES_STUDIO_PRESETS: DropdownChoice[] = []
+
+	//CONF
+	CONF_MICROPHONES: any[] = []
+	CHOICES_CONF_MICROPHONES: DropdownChoice[] = []
+	CONF_PRESET_BANKS: any[] = []
+	CHOICES_CONF_PRESET_BANKS: DropdownChoice[] = []
+	CONF_STATE: any = {}
+
+	//INSITU
+	INSITU_TAGS: any[] = []
+	INSITU_ACTIVE_TAGS: any[] = []
+	CHOICES_INSITU_TAGS: DropdownChoice[] = []
+	INSITU_LAYOUTS: any[] = []
+	INSITU_ACTIVE_LAYOUT: any = {}
+	CHOICES_INSITU_LAYOUTS: DropdownChoice[] = []
+	INSITU_PRESETS: any[] = []
+	CHOICES_INSITU_PRESETS: DropdownChoice[] = []
 
 	COMPOSER_FILES: any[] = [] //list of composer files
 	COMPOSER_FILE_SELECTED: any = {} //currently selected composer file
@@ -35,122 +81,132 @@ export class MulticamInstance extends InstanceBase<ModuleConfig> {
 	COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION: any = {} //currently selected composition in selected composer
 	COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION_ID: string = '' //id of currently selected composition in selected composer
 
-	CHOICES_COMPOSER_FILES: { id: string; label: string }[] = [] //choices for composer files
-	CHOICES_COMPOSER_COMPOSITIONS: { id: string; label: string }[] = [] //choices for compositions in selected composer file
-	CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS: { id: string; label: string }[] = [] //choices for elements in selected composition
+	CHOICES_COMPOSER_FILES: DropdownChoice[] = [] //choices for composer files
+	CHOICES_COMPOSER_COMPOSITIONS: DropdownChoice[] = [] //choices for compositions in selected composer file
+	CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS: DropdownChoice[] = [] //choices for elements in selected composition
 
-	CHOICES_VIDEO_SOURCES: { id: string; label: string }[] = []
+	CHOICES_VIDEO_SOURCES: DropdownChoice[] = []
+	CHOICES_RECORDING_AUX_SOURCES: DropdownChoice[] = []
 
-	CHOICES_MEDIALIST_SELECTED_MEDIA: { id: string; label: string }[] = [] //choices for media in selected medialist
+	CHOICES_MEDIALIST_SELECTED_MEDIA: DropdownChoice[] = [] //choices for media in selected medialist
 	/** All media in all medialists; id is `medialistId|mediaId`, label `Medialist Name - Media Name`. */
-	CHOICES_MEDIALISTS_MEDIA: { id: string; label: string }[] = []
+	CHOICES_MEDIALISTS_MEDIA: DropdownChoice[] = []
 	MEDIALISTS: any[] = [] //list of medialists
-	CHOICES_MEDIALISTS: { id: string; label: string }[] = [] //choices for medialists
+	CHOICES_MEDIALISTS: DropdownChoice[] = [] //choices for medialists
 	MEDIALIST_SELECTED: any = {} //currently selected medialist
 	MEDIALIST_SELECTED_MEDIA: any[] = [] //media items in selected medialist
-	CHOICES_RADIO_PRESET_BANKS: { id: string; label: string }[] = [] //choices for radio preset banks
+	CHOICES_RADIO_PRESET_BANKS: DropdownChoice[] = [] //choices for radio preset banks
 	RADIO_PRESET_BANKS: any[] = [] //list of radio preset banks
+	RADIO_MICROPHONES: any[] = []
+	CHOICES_RADIO_MICROPHONES: DropdownChoice[] = []
+	RADIO_STATE: any = {}
+	RADIO_AUTOMATION_VARIABLES: any[] = []
+
+	//PUBLISHER
+	PUBLISHER_RECORDINGS: any[] = []
+	CHOICES_PUBLISHER_RECORDINGS: DropdownChoice[] = []
+	PUBLISHER_WORKFLOWS: any[] = []
+	CHOICES_PUBLISHER_WORKFLOWS: DropdownChoice[] = []
+	SIGNALR_PUBLISHING_JOBS: any[] = []
+	SIGNALR_CROP_ZONES: any[] = []
+	CHOICES_SIGNALR_CROP_ZONES: DropdownChoice[] = []
+	SIGNALR_NETWORK_SHARE: any = null
+	SIGNALR_PAGED_RECORDINGS: any = null
+	SIGNALR_SELECTED_MICROPHONE: number = -1
+	SIGNALR_ZOOM_ENABLED: boolean = false
+	SIGNALR_CONNECTED: boolean = false
+	SIGNALR_LAST_EVENT: string = ''
+	SIGNALR_LAST_PAYLOAD: string = ''
 
 	//SCENES
 	SCENE_FILES: any[] = [] //list of scene files
 	SCENES_FILE_SELECTED: any = {} //currently selected scene file
-	CHOICES_SCENES_FILES: { id: string; label: string }[] = [] //choices for scene files
+	CHOICES_SCENES_FILES: DropdownChoice[] = [] //choices for scene files
 	SCENES_FILE_SELECTED_SCENES: any[] = [] //scenes in currently selected scene file
-	CHOICES_SCENES_FILE_SELECTED_SCENES: { id: string; label: string }[] = [] //choices for scenes in selected scene file
+	CHOICES_SCENES_FILE_SELECTED_SCENES: DropdownChoice[] = [] //choices for scenes in selected scene file
 	SCENES_FILE_SELECTED_SCENE: any = {} //currently selected scene in selected scene file
 	SCENES_FILE_SELECTED_SCENE_ID: string = '' //id of currently selected scene in selected scene file
 
-	CHOICES_STREAMING_CATALOGS: { id: string; label: string }[] = [] //choices for streaming catalogs
-	CHOICES_STREAMING_PROFILES: { id: string; label: string }[] = [] //choices for streaming profiles
+	STREAMING_CATALOG_SELECTED: any = {}
+	STREAMING_PROFILES: any[] = []
+	CHOICES_STREAMING_CATALOGS: DropdownChoice[] = [] //choices for streaming catalogs
+	CHOICES_STREAMING_PROFILES: DropdownChoice[] = [] //choices for streaming profiles
 
 	//TITLER
 	TITLER_FILES: any[] = [] //list of titler files
-	CHOICES_TITLER_FILES: { id: string; label: string }[] = [] //choices for titler files
+	TITLER_FILE_SELECTED: any = {} //currently selected titler file
+	CHOICES_TITLER_FILES: DropdownChoice[] = [] //choices for titler files
 	TITLER_SELECTED_FILE_ELEMENTS: any[] = [] //elements in currently selected titler file
-	CHOICES_TITLER_ELEMENTS: { id: string; label: string }[] = [] //choices for titler elements
-	CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS: { id: string; label: string }[] = [] //choices for titler elements speaker rows
-	CHOICES_TITLER_ELEMENTS_PANEL_ROWS: { id: string; label: string }[] = [] //choices for titler elements panel rows
+	CHOICES_TITLER_ELEMENTS: DropdownChoice[] = [] //choices for titler elements
+	CHOICES_TITLER_SPEAKER_ELEMENTS: DropdownChoice[] = []
+	CHOICES_TITLER_PANEL_ELEMENTS: DropdownChoice[] = []
+	CHOICES_TITLER_TICKER_ELEMENTS: DropdownChoice[] = []
+	CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS: DropdownChoice[] = [] //choices for titler elements speaker rows
+	CHOICES_TITLER_ELEMENTS_PANEL_ROWS: DropdownChoice[] = [] //choices for titler elements panel rows
+	TITLER_ELEMENT_STRUCTURES: Record<string, any> = {}
 
 	//STATUS
 	RECORDING: boolean = false //recording is currently active
+	RECORDING_PAUSED: boolean = false
+	RECORDING_LIVE_EXTRACT: any = {}
 	ACTIVE_STREAMS: StreamingProfile[] = [] //profiles in the selected streaming catalog
+	VIDEO_LIVE_SOURCE: string = ''
+	VIDEO_MIXER: any = {}
+	MEDIA_CONSTRAINTS: any = {}
 
 	pollInterval: NodeJS.Timeout | null = null
 	_signalR: signalR.HubConnection | null = null
+	private connectionAttempt = 0
+	private isDestroyed = false
 
 	constructor(internal: unknown) {
 		super(internal)
 
 		this.CHOICES_APPLICATIONS = [{ id: 'none', label: 'None' }] //default value
+		this.CHOICES_APPLICATION_TEMPLATES = [{ id: 'none', label: 'None' }]
 
 		this.CHOICES_AUDIO_PROFILES = [{ id: 'none', label: 'None' }] //default value
+		this.CHOICES_CAMERA_SOURCES = Array.from({ length: 40 }, (_, index) => ({
+			id: `CAM${index + 1}`,
+			label: `CAM${index + 1}`,
+		}))
+		this.CHOICES_CAMERA_INDEXES = Array.from({ length: 40 }, (_, index) => ({
+			id: String(index),
+			label: `Camera ${index + 1} (index ${index})`,
+		}))
+		this.CHOICES_PILOT_SEQUENCES = [{ id: 'none', label: 'None' }]
+		this.CHOICES_STUDIO_PRESETS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_CONF_MICROPHONES = [{ id: 'none', label: 'None' }]
+		this.CHOICES_CONF_PRESET_BANKS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_INSITU_TAGS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_INSITU_LAYOUTS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_INSITU_PRESETS = [{ id: 'none', label: 'None' }]
 
 		this.CHOICES_COMPOSER_FILES = [{ id: 'none', label: 'None' }] //default value
 		this.CHOICES_COMPOSER_COMPOSITIONS = [{ id: 'none', label: 'None' }] //default value
 		this.CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS = [{ id: 'none', label: 'None' }] //default value
 
 		this.CHOICES_VIDEO_SOURCES = [
-			{ id: 'Unknown', label: 'Unknown' },
-			{ id: 'VGA', label: 'VGA' },
-			{ id: 'CAM1', label: 'CAM1' },
-			{ id: 'CAM2', label: 'CAM2' },
-			{ id: 'CAM3', label: 'CAM3' },
-			{ id: 'CAM4', label: 'CAM4' },
-			{ id: 'CAM5', label: 'CAM5' },
-			{ id: 'CAM6', label: 'CAM6' },
-			{ id: 'CAM7', label: 'CAM7' },
-			{ id: 'CAM8', label: 'CAM8' },
-			{ id: 'CAM9', label: 'CAM9' },
-			{ id: 'CAM10', label: 'CAM10' },
-			{ id: 'CAM11', label: 'CAM11' },
-			{ id: 'CAM12', label: 'CAM12' },
-			{ id: 'CAM13', label: 'CAM13' },
-			{ id: 'CAM14', label: 'CAM14' },
-			{ id: 'CAM15', label: 'CAM15' },
-			{ id: 'CAM16', label: 'CAM16' },
-			{ id: 'CAM17', label: 'CAM17' },
-			{ id: 'CAM18', label: 'CAM18' },
-			{ id: 'CAM19', label: 'CAM19' },
-			{ id: 'CAM20', label: 'CAM20' },
-			{ id: 'CAM21', label: 'CAM21' },
-			{ id: 'CAM22', label: 'CAM22' },
-			{ id: 'CAM23', label: 'CAM23' },
-			{ id: 'CAM24', label: 'CAM24' },
-			{ id: 'CAM25', label: 'CAM25' },
-			{ id: 'CAM26', label: 'CAM26' },
-			{ id: 'CAM27', label: 'CAM27' },
-			{ id: 'CAM28', label: 'CAM28' },
-			{ id: 'CAM29', label: 'CAM29' },
-			{ id: 'CAM30', label: 'CAM30' },
-			{ id: 'CAM31', label: 'CAM31' },
-			{ id: 'CAM32', label: 'CAM32' },
-			{ id: 'CAM33', label: 'CAM33' },
-			{ id: 'CAM34', label: 'CAM34' },
-			{ id: 'CAM35', label: 'CAM35' },
-			{ id: 'CAM36', label: 'CAM36' },
-			{ id: 'CAM37', label: 'CAM37' },
-			{ id: 'CAM38', label: 'CAM38' },
-			{ id: 'CAM39', label: 'CAM39' },
-			{ id: 'CAM40', label: 'CAM40' },
-			{ id: 'AUDIO1', label: 'AUDIO1' },
-			{ id: 'AUDIO2', label: 'AUDIO2' },
-			{ id: 'AUDIO3', label: 'AUDIO3' },
-			{ id: 'AUDIO4', label: 'AUDIO4' },
-			{ id: 'AUDIO5', label: 'AUDIO5' },
-			{ id: 'AUDIO6', label: 'AUDIO6' },
-			{ id: 'AUDIO7', label: 'AUDIO7' },
-			{ id: 'AUDIO8', label: 'AUDIO8' },
-			{ id: 'Playlist', label: 'Playlist' },
-			{ id: 'Output', label: 'Output' },
-			{ id: 'Composition', label: 'Composition' },
-			{ id: 'File', label: 'File' },
-			{ id: 'WebRTC', label: 'WebRTC' },
-		] //choices for video sources (cameras, screen captures, etc.)
+			...Array.from({ length: 40 }, (_, index) => ({
+				id: `Source ${index + 1}`,
+				label: `Source ${index + 1}`,
+			})),
+			{ id: 'PC Input', label: 'PC Input' },
+			{ id: 'Medialist', label: 'Medialist' },
+		]
+		this.CHOICES_RECORDING_AUX_SOURCES = Array.from({ length: 40 }, (_, index) => ({
+			id: `Source ${index + 1}`,
+			label: `Source ${index + 1}`,
+		}))
 
 		this.CHOICES_MEDIALIST_SELECTED_MEDIA = [{ id: 'none', label: 'None' }] //default value
 		this.CHOICES_MEDIALISTS_MEDIA = [{ id: 'None', label: 'None' }]
 
 		this.CHOICES_RADIO_PRESET_BANKS = [{ id: 'none', label: 'None' }] //default value
+		this.CHOICES_RADIO_MICROPHONES = [{ id: 'none', label: 'None' }]
+		this.CHOICES_PUBLISHER_RECORDINGS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_PUBLISHER_WORKFLOWS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_SIGNALR_CROP_ZONES = [{ id: 'none', label: 'None' }]
 
 		this.CHOICES_SCENES_FILES = [{ id: 'none', label: 'None' }] //default value
 		this.CHOICES_SCENES_FILE_SELECTED_SCENES = [{ id: 'none', label: 'None' }] //default value
@@ -160,35 +216,40 @@ export class MulticamInstance extends InstanceBase<ModuleConfig> {
 
 		this.CHOICES_TITLER_FILES = [{ id: 'none', label: 'None' }] //default value
 		this.CHOICES_TITLER_ELEMENTS = [{ id: 'none', label: 'None' }] //default value
+		this.CHOICES_TITLER_SPEAKER_ELEMENTS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_TITLER_PANEL_ELEMENTS = [{ id: 'none', label: 'None' }]
+		this.CHOICES_TITLER_TICKER_ELEMENTS = [{ id: 'none', label: 'None' }]
 		this.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS = [{ id: 'none', label: 'None' }] //default value
 		this.CHOICES_TITLER_ELEMENTS_PANEL_ROWS = [{ id: 'none', label: 'None' }] //default value
 	}
 
-	async init(config: ModuleConfig): Promise<void> {
+	async init(config: ModuleConfig, _isFirstInit: boolean, secrets: ModuleSecrets): Promise<void> {
 		this.config = config
-		this.updateActions() // export actions
+		this.secrets = secrets ?? { apiKey: '' }
+		this.isDestroyed = false
+		this.updateActions(false) // export actions; presets are exported after feedbacks
 		this.updateFeedbacks() // export feedbacks
+		this.updatePresets() // export presets
 		this.updateVariableDefinitions() // export variable definitions
-
-		try {
-			await this.initConnection()
-		} catch (error) {
-			this.log('error', `Failed to initialize connection: ${error}`)
-		}
+		this.startConnection()
 	}
 	// When module gets deleted
 	async destroy(): Promise<void> {
 		this.log('debug', 'destroy')
+		this.isDestroyed = true
+		this.connectionAttempt++
+		stopPolling(this)
+		if (this._signalR) {
+			const connection = this._signalR
+			this._signalR = null
+			await connection.stop()
+		}
 	}
 
-	async configUpdated(config: ModuleConfig): Promise<void> {
+	async configUpdated(config: ModuleConfig, secrets: ModuleSecrets): Promise<void> {
 		this.config = config
-
-		try {
-			await this.initConnection()
-		} catch (error) {
-			this.log('error', `Failed to initialize connection: ${error}`)
-		}
+		this.secrets = secrets ?? { apiKey: '' }
+		this.startConnection()
 	}
 
 	// Return config fields for web config
@@ -196,21 +257,45 @@ export class MulticamInstance extends InstanceBase<ModuleConfig> {
 		return GetConfigFields()
 	}
 
-	updateActions(): void {
+	updateActions(updatePresets: boolean = true): void {
 		UpdateActions(this)
+		if (updatePresets) this.updatePresets()
 	}
 
 	updateFeedbacks(): void {
 		UpdateFeedbacks(this)
 	}
 
+	updatePresets(): void {
+		UpdatePresets(this)
+	}
+
 	updateVariableDefinitions(): void {
 		UpdateVariableDefinitions(this)
 	}
 
-	async initConnection(): Promise<void> {
-		await InitConnection(this)
+	private startConnection(): void {
+		const attempt = ++this.connectionAttempt
+		void this.initConnection(attempt).catch((error) => {
+			if (!this.isDestroyed && attempt === this.connectionAttempt) {
+				this.log('error', `Failed to initialize connection: ${error}`)
+			}
+		})
+	}
+
+	private async initConnection(attempt: number): Promise<void> {
+		const isCurrent = (): boolean => !this.isDestroyed && attempt === this.connectionAttempt
+		if (!isCurrent()) return
+
+		if (this._signalR) {
+			const connection = this._signalR
+			this._signalR = null
+			await connection.stop()
+			if (!isCurrent()) return
+		}
+
+		await InitConnection(this, isCurrent)
 	}
 }
 
-runEntrypoint(MulticamInstance, UpgradeScripts)
+export default MulticamInstance

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,19 @@
-import { InstanceBase, type SomeCompanionConfigField } from '@companion-module/base'
+import { InstanceBase, InstanceStatus, type SomeCompanionConfigField } from '@companion-module/base'
 import { GetConfigFields, type ModuleConfig, type ModuleSecrets } from './config.js'
 import { UpgradeScripts } from './upgrades.js'
 import { UpdateActions, type ActionsSchema } from './actions.js'
 import { UpdateFeedbacks, type FeedbacksSchema } from './feedbacks.js'
 import { UpdatePresets } from './presets.js'
 import { UpdateVariableDefinitions, type VariablesSchema } from './variables.js'
-import { InitConnection } from './api.js'
+import { InitConnection, ProbeConnection } from './api.js'
 import type * as signalR from '@microsoft/signalr'
 import { stopPolling } from './polling.js'
+import { cancelSignalRReconnect } from './signalr.js'
+
+const CONNECTION_HEALTH_CHECK_INTERVAL_MS = 5000
+const CONNECTION_HEALTH_FAILURE_THRESHOLD = 2
+const CONNECTION_RETRY_BASE_MS = 2000
+const CONNECTION_RETRY_MAX_MS = 30000
 
 export interface StreamingProfile {
 	id: string
@@ -158,6 +164,11 @@ export class MulticamInstance extends InstanceBase<ModuleSchema> {
 	_signalR: signalR.HubConnection | null = null
 	private connectionAttempt = 0
 	private isDestroyed = false
+	private reconnectTimer: NodeJS.Timeout | null = null
+	private healthCheckTimer: NodeJS.Timeout | null = null
+	private healthCheckInFlightForAttempt: number | null = null
+	private healthCheckFailures = 0
+	private connectionRetryCount = 0
 
 	constructor(internal: unknown) {
 		super(internal)
@@ -238,7 +249,9 @@ export class MulticamInstance extends InstanceBase<ModuleSchema> {
 		this.log('debug', 'destroy')
 		this.isDestroyed = true
 		this.connectionAttempt++
+		this.clearConnectionTimers()
 		stopPolling(this)
+		cancelSignalRReconnect(this)
 		if (this._signalR) {
 			const connection = this._signalR
 			this._signalR = null
@@ -276,17 +289,26 @@ export class MulticamInstance extends InstanceBase<ModuleSchema> {
 
 	private startConnection(): void {
 		const attempt = ++this.connectionAttempt
+		this.clearConnectionTimers()
+		this.connectionRetryCount = 0
+		stopPolling(this)
+		this.launchConnectionAttempt(attempt)
+	}
+
+	private launchConnectionAttempt(attempt: number): void {
 		void this.initConnection(attempt).catch((error) => {
-			if (!this.isDestroyed && attempt === this.connectionAttempt) {
+			if (this.isCurrentConnectionAttempt(attempt)) {
 				this.log('error', `Failed to initialize connection: ${error}`)
+				this.scheduleConnectionRetry(attempt)
 			}
 		})
 	}
 
 	private async initConnection(attempt: number): Promise<void> {
-		const isCurrent = (): boolean => !this.isDestroyed && attempt === this.connectionAttempt
+		const isCurrent = (): boolean => this.isCurrentConnectionAttempt(attempt)
 		if (!isCurrent()) return
 
+		cancelSignalRReconnect(this)
 		if (this._signalR) {
 			const connection = this._signalR
 			this._signalR = null
@@ -294,7 +316,93 @@ export class MulticamInstance extends InstanceBase<ModuleSchema> {
 			if (!isCurrent()) return
 		}
 
-		await InitConnection(this, isCurrent)
+		const connected = await InitConnection(this, isCurrent)
+		if (!isCurrent()) return
+
+		if (connected) {
+			this.connectionRetryCount = 0
+			this.startConnectionHealthCheck(attempt)
+		} else {
+			this.scheduleConnectionRetry(attempt)
+		}
+	}
+
+	private isCurrentConnectionAttempt(attempt: number): boolean {
+		return !this.isDestroyed && attempt === this.connectionAttempt
+	}
+
+	private scheduleConnectionRetry(attempt: number): void {
+		if (!this.isCurrentConnectionAttempt(attempt) || this.reconnectTimer || !this.config.host || !this.config.port) {
+			return
+		}
+
+		const delay = Math.min(
+			CONNECTION_RETRY_BASE_MS * 2 ** Math.min(this.connectionRetryCount, 4),
+			CONNECTION_RETRY_MAX_MS,
+		)
+		this.connectionRetryCount++
+		const delaySeconds = Math.ceil(delay / 1000)
+		this.updateStatus(InstanceStatus.ConnectionFailure, `Multicam unavailable - retrying in ${delaySeconds}s`)
+		this.log('warn', `Multicam unavailable; retrying /api/application/version in ${delaySeconds}s`)
+
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null
+			if (this.isCurrentConnectionAttempt(attempt)) this.launchConnectionAttempt(attempt)
+		}, delay)
+	}
+
+	private startConnectionHealthCheck(attempt: number): void {
+		if (this.healthCheckTimer) clearInterval(this.healthCheckTimer)
+		this.healthCheckFailures = 0
+		this.healthCheckTimer = setInterval(() => {
+			void this.checkConnectionHealth(attempt)
+		}, CONNECTION_HEALTH_CHECK_INTERVAL_MS)
+	}
+
+	private async checkConnectionHealth(attempt: number): Promise<void> {
+		if (!this.isCurrentConnectionAttempt(attempt) || this.healthCheckInFlightForAttempt === attempt) return
+
+		this.healthCheckInFlightForAttempt = attempt
+		let connected = false
+		try {
+			connected = await ProbeConnection(this)
+		} finally {
+			if (this.healthCheckInFlightForAttempt === attempt) this.healthCheckInFlightForAttempt = null
+		}
+
+		if (!this.isCurrentConnectionAttempt(attempt)) return
+		if (connected) {
+			this.healthCheckFailures = 0
+			return
+		}
+
+		this.healthCheckFailures++
+		if (this.healthCheckFailures < CONNECTION_HEALTH_FAILURE_THRESHOLD) {
+			this.log('warn', 'Multicam health check failed once; waiting for confirmation')
+			return
+		}
+
+		this.log('warn', 'Connection to Multicam lost; starting automatic reconnection')
+		this.updateStatus(InstanceStatus.ConnectionFailure, 'Connection lost - reconnecting...')
+		if (this.healthCheckTimer) {
+			clearInterval(this.healthCheckTimer)
+			this.healthCheckTimer = null
+		}
+		stopPolling(this)
+		this.connectionRetryCount = 0
+		this.launchConnectionAttempt(attempt)
+	}
+
+	private clearConnectionTimers(): void {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer)
+			this.reconnectTimer = null
+		}
+		if (this.healthCheckTimer) {
+			clearInterval(this.healthCheckTimer)
+			this.healthCheckTimer = null
+		}
+		this.healthCheckFailures = 0
 	}
 }
 

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -1,15 +1,37 @@
-import type { MulticamInstance } from './main.js'
+import type { DropdownChoice, MulticamInstance, StreamingProfile } from './main.js'
 
-let pollInterval: NodeJS.Timeout | undefined = undefined
-
-/** Suppress repeated identical fetch errors (e.g. many endpoints failing when Multicam closes) until a request succeeds. */
 type FetchErrorDedupeState = {
 	suppressDuplicateMessage: string | null
 }
 
-const fetchErrorDedupeByInstance = new WeakMap<MulticamInstance, FetchErrorDedupeState>()
+export type PollScope =
+	| 'application'
+	| 'automation'
+	| 'composer'
+	| 'medialist'
+	| 'publisher'
+	| 'recording'
+	| 'scenes'
+	| 'streaming'
+	| 'titler'
+	| 'video'
 
-function getFetchErrorDedupeState(self: MulticamInstance): FetchErrorDedupeState {
+export type PollOptions = {
+	/** Also read state endpoints normally replaced by SignalR while it is connected. */
+	forceSignalRRefresh?: boolean
+}
+
+type PollQueueState = {
+	running: Promise<void> | null
+	activeFull: boolean
+	fullRequested: boolean
+	forceSignalRRefresh: boolean
+	scopes: Set<PollScope>
+}
+
+const pollQueueByInstance = new WeakMap<MulticamInstance, PollQueueState>()
+const fetchErrorDedupeByInstance = new WeakMap<MulticamInstance, FetchErrorDedupeState>()
+function getFetchErrorDedupeState(self: MulticamInstance) {
 	let s = fetchErrorDedupeByInstance.get(self)
 	if (!s) {
 		s = { suppressDuplicateMessage: null }
@@ -17,97 +39,185 @@ function getFetchErrorDedupeState(self: MulticamInstance): FetchErrorDedupeState
 	}
 	return s
 }
-
-function markFetchSucceeded(self: MulticamInstance): void {
+function markFetchSucceeded(self: MulticamInstance) {
 	const s = fetchErrorDedupeByInstance.get(self)
 	if (s) {
 		s.suppressDuplicateMessage = null
 	}
 }
-
 export function startPolling(self: MulticamInstance): void {
-	stopPolling()
-
+	stopPolling(self)
 	//poll once
 	void runPollCycle(self)
-
 	let interval = 30000
-
 	if (!self.config.enablePolling) {
 		self.log('info', 'Polling is disabled in config, use "Manually Refresh Data" action to update data')
 	} else {
 		interval = Number(self.config.pollingInterval || 5000)
-
 		if (!interval || isNaN(interval)) {
 			self.log('error', 'Invalid polling interval in config')
 			return
 		}
-
 		self.pollInterval = setInterval(() => {
 			void runPollCycle(self)
 		}, interval)
-
 		self.log('info', `Started polling every ${interval}ms`)
 	}
 }
-
-export function stopPolling(): void {
-	if (pollInterval) {
-		clearInterval(pollInterval)
-		pollInterval = undefined
+export function stopPolling(self?: MulticamInstance): void {
+	if (self?.pollInterval) {
+		clearInterval(self.pollInterval)
+		self.pollInterval = null
 	}
 }
+export async function runPollCycle(self: MulticamInstance, options: PollOptions = {}): Promise<void> {
+	return queuePollRequest(self, true, [], options)
+}
 
-export async function runPollCycle(self: MulticamInstance): Promise<void> {
+/** Refresh only the HTTP resources whose SignalR event did not carry a complete payload. */
+export async function runPollScopes(
+	self: MulticamInstance,
+	scopes: Iterable<PollScope>,
+	options: PollOptions = {},
+): Promise<void> {
+	return queuePollRequest(self, false, scopes, options)
+}
+
+function getPollQueue(self: MulticamInstance): PollQueueState {
+	let state = pollQueueByInstance.get(self)
+	if (!state) {
+		state = {
+			running: null,
+			activeFull: false,
+			fullRequested: false,
+			forceSignalRRefresh: false,
+			scopes: new Set<PollScope>(),
+		}
+		pollQueueByInstance.set(self, state)
+	}
+	return state
+}
+
+async function queuePollRequest(
+	self: MulticamInstance,
+	full: boolean,
+	scopes: Iterable<PollScope>,
+	options: PollOptions,
+): Promise<void> {
+	const state = getPollQueue(self)
+	if (full) {
+		// Interval ticks are coalesced while a complete cycle is already running.
+		if (state.activeFull && !options.forceSignalRRefresh) return state.running as Promise<void>
+		state.fullRequested = true
+	} else {
+		for (const scope of scopes) state.scopes.add(scope)
+	}
+	state.forceSignalRRefresh ||= Boolean(options.forceSignalRRefresh)
+	if (!state.running) state.running = Promise.resolve().then(async () => drainPollQueue(self, state))
+	return state.running
+}
+
+async function drainPollQueue(self: MulticamInstance, state: PollQueueState): Promise<void> {
 	try {
-		await pollApplication(self)
-		await pollAudio(self)
-		await pollConf(self)
-		await pollComposer(self)
-		await pollInsitu(self)
-		await pollMedialist(self)
-		await pollPublisher(self)
-		await pollRadio(self)
-		await pollRecording(self)
-		await pollScenes(self)
-		await pollStreaming(self)
-		await pollStudio(self)
-		await pollTitler(self)
-		await pollVideo(self)
-	} catch (err) {
-		self.log('error', `Polling failed: ${err}`)
-		//console.log('log', `${err}`)
-		//stopPolling()
+		while (state.fullRequested || state.scopes.size > 0) {
+			const full = state.fullRequested
+			const scopes = new Set(state.scopes)
+			const forceSignalRRefresh = state.forceSignalRRefresh
+			state.fullRequested = false
+			state.forceSignalRRefresh = false
+			state.scopes.clear()
+
+			try {
+				state.activeFull = full
+				if (full) {
+					await executeFullPoll(self, forceSignalRRefresh)
+					if (scopes.size > 0) await executeScopedPoll(self, scopes, forceSignalRRefresh)
+				} else {
+					await executeScopedPoll(self, scopes, forceSignalRRefresh)
+				}
+			} catch (err) {
+				self.log('error', `Polling failed: ${err}`)
+			} finally {
+				state.activeFull = false
+			}
+		}
+	} finally {
+		state.running = null
 	}
 }
 
-async function pollApplication(self: MulticamInstance) {
+async function executeFullPoll(self: MulticamInstance, forceSignalRRefresh: boolean): Promise<void> {
+	// Capture this once: the initial cycle must remain a complete HTTP snapshot even if SignalR connects mid-cycle.
+	const includeSignalRState = forceSignalRRefresh || !self.SIGNALR_CONNECTED
+	await pollApplication(self, includeSignalRState)
+	await pollConf(self)
+	await pollComposer(self, includeSignalRState)
+	await pollInsitu(self)
+	await pollMedialist(self, includeSignalRState)
+	await pollPublisher(self)
+	await pollRadio(self)
+	await pollRecording(self)
+	await pollScenes(self, includeSignalRState)
+	await pollStreaming(self, includeSignalRState)
+	await pollStudio(self)
+	await pollTitler(self, includeSignalRState)
+	await pollVideo(self)
+	await pollApiState(self, fetchData, updateVariable, includeSignalRState)
+}
+
+async function executeScopedPoll(
+	self: MulticamInstance,
+	scopes: Set<PollScope>,
+	forceSignalRRefresh: boolean,
+): Promise<void> {
+	const includeSignalRState = forceSignalRRefresh || !self.SIGNALR_CONNECTED
+	const flags: UpdateFlags = { actions: false, feedbacks: false }
+	if (scopes.has('application')) await pollApplication(self, includeSignalRState)
+	if (scopes.has('composer')) await pollComposer(self, includeSignalRState)
+	if (scopes.has('medialist')) await pollMedialist(self, includeSignalRState)
+	if (scopes.has('publisher')) await pollApiPublisher(self, fetchData, updateVariable, flags, includeSignalRState)
+	if (scopes.has('recording')) await pollApiRecording(self, fetchData, updateVariable, includeSignalRState)
+	if (scopes.has('scenes')) await pollScenes(self, includeSignalRState)
+	if (scopes.has('streaming')) await pollStreaming(self, true)
+	if (scopes.has('titler')) {
+		await pollTitler(self, includeSignalRState)
+		await pollTitlerStructures(self, fetchData, updateVariable, flags)
+	}
+	if (scopes.has('video')) await pollApiVideo(self, fetchData, updateVariable, flags, includeSignalRState)
+	if (scopes.has('automation')) {
+		const running = self.RUNNING_APPLICATION.toLowerCase().replace(/\s+/g, '')
+		if (running.includes('conf')) await pollApiConf(self, fetchData, updateVariable, flags)
+		if (running.includes('radio')) await pollApiRadio(self, fetchData, updateVariable, flags)
+	}
+
+	if (scopes.has('streaming')) syncActiveStreamsFromProfiles(self)
+	if (flags.actions) self.updateActions()
+	if (flags.feedbacks) self.updateFeedbacks()
+	self.checkAllFeedbacks()
+}
+
+async function pollApplication(self: MulticamInstance, includeSignalRState: boolean = true) {
 	//get system information
 	self.log('debug', 'Polling application/system information')
-
 	const data = await fetchData(self, '/api/application/system')
 	if (data) {
 		await updateVariable(self, 'computerName', data.ComputerName)
 		await updateVariable(self, 'multicamName', data.MulticamName)
 	}
-
 	const licensedApps = await fetchData(self, '/api/application')
-	if (licensedApps) {
+	if (Array.isArray(licensedApps)) {
 		self.APPLICATIONS = licensedApps
 		await updateVariable(self, 'licensedApps', licensedApps.join(', '))
-
 		//build CHOICES_APPLICATIONS
 		//it is just a string array
 		const choices = []
 		for (const app of licensedApps) {
 			choices.push({ id: app, label: app })
 		}
-
 		//if no licensed apps, add 'None' choice
 		if (choices.length === 0) {
 			choices.push({ id: 'None', label: 'None' })
 		}
-
 		//only update if choices have changed
 		if (JSON.stringify(self.CHOICES_APPLICATIONS) !== JSON.stringify(choices)) {
 			self.CHOICES_APPLICATIONS = choices
@@ -115,27 +225,47 @@ async function pollApplication(self: MulticamInstance) {
 			self.updateFeedbacks()
 		}
 	}
-
 	const version = await fetchData(self, '/api/application/version')
 	if (version) {
 		await updateVariable(self, 'applicationVersion', version)
 	}
-
 	//get templates for every licensed Application
+	self.APPLICATION_TEMPLATES = {}
+	const templateChoices = []
 	for (const app of self.APPLICATIONS) {
-		const templates = await fetchData(self, `/api/application/templates/${app}`)
-		if (templates) {
-			await updateVariable(self, `templates_${app}`, templates)
+		const templates = await fetchData(self, `/api/application/templates/${encodeURIComponent(String(app))}`)
+		if (Array.isArray(templates)) {
+			self.APPLICATION_TEMPLATES[String(app)] = templates
+			for (const template of templates) {
+				if (template?.Name) {
+					templateChoices.push({
+						id: JSON.stringify([String(app), String(template.Name)]),
+						label: `${app} - ${template.Name}`,
+					})
+				}
+			}
 		}
 	}
-
+	await updateVariable(self, 'applicationTemplates', JSON.stringify(self.APPLICATION_TEMPLATES))
+	if (templateChoices.length === 0) templateChoices.push({ id: 'none', label: 'None' })
+	if (JSON.stringify(self.CHOICES_APPLICATION_TEMPLATES) !== JSON.stringify(templateChoices)) {
+		self.CHOICES_APPLICATION_TEMPLATES = templateChoices
+		self.updateActions()
+	}
 	//get rooms
 	const rooms = await fetchData(self, '/api/application/rooms')
-	if (rooms) {
+	if (Array.isArray(rooms)) {
 		self.ROOMS = rooms
-		await updateVariable(self, 'rooms', rooms.join(', '))
+		await updateVariable(
+			self,
+			'rooms',
+			rooms
+				.map((room) => room?.Name)
+				.filter(Boolean)
+				.join(', '),
+		)
 		//Build CHOICES_ROOMS
-		const choices = rooms.map((r: any) => {
+		const choices = rooms.map((r) => {
 			return { id: r.Id, label: r.Name }
 		})
 		if (choices.length === 0) {
@@ -146,81 +276,56 @@ async function pollApplication(self: MulticamInstance) {
 			self.updateActions()
 		}
 	}
-
 	//get selected room
 	const selectedRoom = await fetchData(self, '/api/application/rooms/selected')
-	if (selectedRoom) {
+	if (selectedRoom && typeof selectedRoom === 'object' && !Array.isArray(selectedRoom)) {
 		self.ROOM_SELECTED = selectedRoom
 		await updateVariable(self, 'selected_room', selectedRoom.Name || '')
+		await updateVariable(self, 'selectedRoomId', selectedRoom.Id || '')
 	}
-
-	//get running application
-	const runningApp = await fetchData(self, '/api/application/running')
-	if (runningApp) {
-		await updateVariable(self, 'runningApp', runningApp || 'None')
-	} else {
-		await updateVariable(self, 'runningApp', 'None')
-	}
-
-	//get auto/manual state of application
-	const appState = await fetchData(self, '/api/application/auto')
-	if (appState) {
-		await updateVariable(self, 'applicationAutoState', appState ? 'Auto' : 'Manual')
-	}
-
-	//get snapshot of application
-	const snapshot = await fetchData(self, '/api/application/snapshot')
-	if (snapshot) {
-		await updateVariable(self, 'applicationSnapshot', snapshot || 'None')
-	}
-}
-
-async function pollAudio(_self: MulticamInstance) {
-	//get audio profiles
-	//self.log('info', 'Polling audio profiles')
-	/*const profiles = await fetchData(self, '/api/v1/audio/profiles')
-	if (profiles) {
-		self.AUDIO_PROFILES = profiles
-		await updateVariable(self, 'audio_profiles', profiles.map((p: any) => p.Name).join(', '))
-
-		//build CHOICES_AUDIO_PROFILES
-		const choices = profiles.map((p: any) => {
-			return { id: p.Name, label: p.Name }
-		})
-		if (choices.length === 0) {
-			choices.push({ id: 'None', label: 'None' })
+	if (includeSignalRState) {
+		// SignalR keeps these values current after the initial snapshot and after reconnect reconciliation.
+		const runningApp = await fetchData(self, '/api/application/running')
+		if (runningApp) {
+			self.RUNNING_APPLICATION = String(runningApp)
+			await updateVariable(self, 'runningApp', runningApp || 'None')
+		} else {
+			self.RUNNING_APPLICATION = ''
+			await updateVariable(self, 'runningApp', 'None')
 		}
-		self.CHOICES_AUDIO_PROFILES = choices
-		self.updateActions()
-		self.updateFeedbacks()
+		const appState = await fetchData(self, '/api/application/auto')
+		if (typeof appState === 'boolean') {
+			await updateVariable(self, 'applicationAutoState', appState ? 'Auto' : 'Manual')
+		}
 	}
-
-	//get selected audio profile
-	const selectedProfile = await fetchData(self, '/api/v1/audio/profiles/selected')
-	if (selectedProfile) {
-		self.AUDIO_PROFILE_SELECTED = selectedProfile
-		await updateVariable(self, 'selected_audio_profile', selectedProfile.Name || '')
-	}*/
 }
 
-async function pollComposer(self: MulticamInstance) {
+async function pollComposer(self: MulticamInstance, includeSignalRState: boolean = true) {
 	self.log('debug', 'Polling Composer')
-
 	//get composer files
 	const files = await fetchData(self, '/api/v3/composer')
-	if (files && files !== 'Application not launched!') {
+	if (Array.isArray(files)) {
 		self.COMPOSER_FILES = files
-
+		if (!includeSignalRState) {
+			const selectedId =
+				typeof self.COMPOSER_FILE_SELECTED === 'string'
+					? self.COMPOSER_FILE_SELECTED
+					: String(self.COMPOSER_FILE_SELECTED?.ComposerFileId ?? self.COMPOSER_FILE_SELECTED?.Id ?? '')
+			const selected = files.find((file) => String(file?.ComposerFileId ?? file?.Id ?? '') === selectedId)
+			if (selected) {
+				self.COMPOSER_FILE_SELECTED = selectedId
+				await updateVariable(self, 'composerSelectedFileName', selected.ComposerFileName ?? selected.Name ?? '')
+				await updateVariable(self, 'composerSelectedFileId', selectedId)
+			}
+		}
 		//console.log('files', files)
-
 		//build CHOICES_COMPOSER_FILES
-		const choices = files.map((f: any) => {
+		const choices = files.map((f) => {
 			return { id: f.ComposerFileId, label: f.ComposerFileName }
 		})
 		if (choices.length === 0) {
 			choices.push({ id: 'None', label: 'None' })
 		}
-
 		//only update if choices have changed
 		if (JSON.stringify(self.CHOICES_COMPOSER_FILES) !== JSON.stringify(choices)) {
 			self.CHOICES_COMPOSER_FILES = choices
@@ -230,47 +335,57 @@ async function pollComposer(self: MulticamInstance) {
 	} else {
 		self.log('debug', 'Unable to fetch composer files, application not launched')
 	}
-
-	//get selected composer file
-	const selectedFile = await fetchData(self, '/api/v3/composer/selected')
-	if (selectedFile && selectedFile !== 'Application not launched!') {
-		self.COMPOSER_FILE_SELECTED = selectedFile.ComposerFileId
-		await updateVariable(self, 'composerSelectedFileName', selectedFile.ComposerFileName || '')
-		await updateVariable(self, 'composerSelectedFileId', selectedFile.ComposerFileId || '')
-		self.log('debug', `Selected composer file ID: ${selectedFile.ComposerFileId}`)
-		self.log('debug', `Selected composer file Name: ${selectedFile.ComposerFileName}`)
-	} else {
-		self.log('debug', 'Unable to fetch selected composer file, application not launched')
+	// The selected file is updated by SignalR while connected; HTTP remains the initial/fallback source.
+	if (includeSignalRState) {
+		const selectedFile = await fetchData(self, '/api/v3/composer/selected')
+		if (selectedFile && typeof selectedFile === 'object' && !Array.isArray(selectedFile)) {
+			self.COMPOSER_FILE_SELECTED = selectedFile.ComposerFileId
+			await updateVariable(self, 'composerSelectedFileName', selectedFile.ComposerFileName || '')
+			await updateVariable(self, 'composerSelectedFileId', selectedFile.ComposerFileId || '')
+			self.log('debug', `Selected composer file ID: ${selectedFile.ComposerFileId}`)
+			self.log('debug', `Selected composer file Name: ${selectedFile.ComposerFileName}`)
+		} else {
+			self.log('debug', 'Unable to fetch selected composer file, application not launched')
+		}
 	}
-
 	//get selected composer file's content
 	const content = await fetchData(self, '/api/v3/composer/selected/compositions')
-	if (content && content !== 'Application not launched!') {
-		if (content !== 'No file selected!') {
+	if (Array.isArray(content)) {
+		if (content.length > 0) {
 			self.COMPOSER_FILE_SELECTED_COMPOSITIONS = content
-
+			if (!includeSignalRState) {
+				const selectedId = self.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION_ID
+				const selected = content.find(
+					(composition) => String(composition?.ComposerSceneId ?? composition?.Id ?? '') === selectedId,
+				)
+				if (selected) {
+					self.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION = selected
+					await updateVariable(
+						self,
+						'composerSelectedCompositionSceneName',
+						selected.ComposerSceneName ?? selected.Name ?? '',
+					)
+					await updateVariable(self, 'composerSelectedCompositionSceneId', selectedId)
+				}
+			}
 			//console.log('content', content)
-
 			//build CHOICES_COMPOSER_COMPOSITIONS
-			const choices = content.map((c: any) => {
+			const choices = content.map((c) => {
 				return { id: c.ComposerSceneId, label: c.ComposerSceneName }
 			})
 			if (choices.length === 0) {
 				self.log('debug', 'No compositions found in selected composer file')
 				choices.push({ id: 'None', label: 'None' })
 			}
-
 			//console.log('CHOICES_COMPOSER_COMPOSITIONS:', choices)
-
 			//only update if choices have changed
 			if (JSON.stringify(self.CHOICES_COMPOSER_COMPOSITIONS) !== JSON.stringify(choices)) {
 				self.CHOICES_COMPOSER_COMPOSITIONS = choices
 				self.updateActions()
 				self.updateFeedbacks()
 			}
-
 			//also build CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS
-			const tempChoicesElements: any[] = []
+			const tempChoicesElements = []
 			for (const composition of content) {
 				//console.log('composition', composition)
 				if (composition.ComposerElements) {
@@ -283,14 +398,11 @@ async function pollComposer(self: MulticamInstance) {
 					}
 				}
 			}
-
 			if (tempChoicesElements.length === 0) {
 				self.log('debug', 'No composition elements found in selected composer file')
 				tempChoicesElements.push({ id: 'None', label: 'None' })
 			}
-
 			//console.log('CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS:', tempChoicesElements)
-
 			//only update if choices have changed
 			if (JSON.stringify(self.CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS) !== JSON.stringify(tempChoicesElements)) {
 				self.CHOICES_COMPOSER_COMPOSITIONS_ELEMENTS = tempChoicesElements
@@ -303,19 +415,18 @@ async function pollComposer(self: MulticamInstance) {
 	} else {
 		self.log('debug', 'Unable to fetch composer file content, application not launched')
 	}
-
-	//get selected composition
-	const composition = await fetchData(self, '/api/v3/composer/selected/compositions/selected')
-	if (composition && composition !== 'Application not launched!') {
-		self.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION = composition
-		self.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION_ID = composition.CompositionSceneId || ''
-		await updateVariable(self, 'composerSelectedCompositionSceneName', composition.CompositionSceneName || '')
-		await updateVariable(self, 'composerSelectedCompositionSceneId', composition.CompositionSceneId || '')
-	} else {
-		self.log('debug', 'Unable to fetch selected composition, application not launched')
+	if (includeSignalRState) {
+		const composition = await fetchData(self, '/api/v3/composer/selected/compositions/selected')
+		if (composition && typeof composition === 'object' && !Array.isArray(composition)) {
+			self.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION = composition
+			self.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION_ID = composition.ComposerSceneId || ''
+			await updateVariable(self, 'composerSelectedCompositionSceneName', composition.ComposerSceneName || '')
+			await updateVariable(self, 'composerSelectedCompositionSceneId', composition.ComposerSceneId || '')
+		} else {
+			self.log('debug', 'Unable to fetch selected composition, application not launched')
+		}
 	}
 }
-
 async function pollConf(_self: MulticamInstance) {
 	//self.log('info', 'Polling Conf')
 	//get workspace information
@@ -360,7 +471,6 @@ async function pollConf(_self: MulticamInstance) {
         await updateVariable(self, 'autotitling', autoTitling.Enabled ? 'Enabled' : 'Disabled')
     }*/
 }
-
 async function pollInsitu(_self: MulticamInstance) {
 	//self.log('info', 'Polling Insitu')
 	/*
@@ -377,10 +487,8 @@ async function pollInsitu(_self: MulticamInstance) {
     }
 */
 }
-
 /** Separator between medialist id and media id in {@link MulticamInstance.CHOICES_MEDIALISTS_MEDIA} choice ids. */
 const MEDIALIST_MEDIA_ID_SEP = '|'
-
 /** Parse composite id from {@link buildMedialistsMediaChoices}. */
 export function parseMedialistMediaGlobalChoiceId(choiceId: string): { medialistId: string; mediaId: string } | null {
 	if (!choiceId || choiceId === 'None') return null
@@ -388,18 +496,14 @@ export function parseMedialistMediaGlobalChoiceId(choiceId: string): { medialist
 	if (i <= 0 || i === choiceId.length - 1) return null
 	return { medialistId: choiceId.slice(0, i), mediaId: choiceId.slice(i + 1) }
 }
-
-async function buildMedialistsMediaChoices(
-	self: MulticamInstance,
-	medialists: any[],
-): Promise<{ id: string; label: string }[]> {
+async function buildMedialistsMediaChoices(self: MulticamInstance, medialists: any[]) {
 	const buckets = await Promise.all(
-		medialists.map(async (ml: any) => {
+		medialists.map(async (ml) => {
 			const mlName = String(ml.Name ?? '')
 			const mlId = String(ml.Id ?? '')
-			let items: any[] = Array.isArray(ml.Items) ? ml.Items : []
+			let items = Array.isArray(ml.Items) ? ml.Items : []
 			if (items.length === 0 && mlId) {
-				const detail = await fetchData(self, `/api/v3/medialist/${mlId}`)
+				const detail = await fetchData(self, `/api/v3/medialist/${encodeURIComponent(mlId)}`)
 				if (detail && typeof detail === 'object' && Array.isArray(detail.Items)) {
 					items = detail.Items
 				}
@@ -422,34 +526,56 @@ async function buildMedialistsMediaChoices(
 	return choices
 }
 
-async function pollMedialist(self: MulticamInstance) {
-	self.log('debug', 'Polling Medialist')
+function updateSelectedMedialistChoices(self: MulticamInstance, selectedMedialist: any): void {
+	const medialistName = String(selectedMedialist?.Name ?? selectedMedialist?.name ?? '')
+	const items = Array.isArray(selectedMedialist?.Items)
+		? selectedMedialist.Items
+		: Array.isArray(selectedMedialist?.items)
+			? selectedMedialist.items
+			: []
+	const choices = items.map((media: any) => ({
+		id: String(media?.Id ?? media?.id ?? ''),
+		label: `${medialistName} - ${media?.MediaName ?? media?.mediaName ?? media?.Name ?? media?.name ?? ''}`,
+	}))
+	if (choices.length === 0) choices.push({ id: 'None', label: 'None' })
+	if (JSON.stringify(self.CHOICES_MEDIALIST_SELECTED_MEDIA) !== JSON.stringify(choices)) {
+		self.CHOICES_MEDIALIST_SELECTED_MEDIA = choices
+		self.updateActions()
+		self.updateFeedbacks()
+	}
+}
 
+async function pollMedialist(self: MulticamInstance, includeSignalRState: boolean = true) {
+	self.log('debug', 'Polling Medialist')
 	//get available medialists
 	//api/v3/medialist
-
-	const medialists = await fetchData(self, '/api/v3/medialist')
-	if (medialists && medialists !== 'Application not launched!') {
+	const medialists = await fetchData(self, '/api/v3/medialist?includeMedias=true')
+	if (Array.isArray(medialists)) {
 		self.MEDIALISTS = medialists
-
-		self.checkFeedbacks()
-
+		if (!includeSignalRState) {
+			const selectedId = String(self.MEDIALIST_SELECTED?.Id ?? self.MEDIALIST_SELECTED?.id ?? '')
+			const selected = medialists.find((medialist) => String(medialist?.Id ?? medialist?.id ?? '') === selectedId)
+			if (selected) {
+				self.MEDIALIST_SELECTED = selected
+				updateSelectedMedialistChoices(self, selected)
+				await updateVariable(self, 'medialistSelectedName', selected.Name ?? selected.name ?? '')
+				await updateVariable(self, 'medialistSelectedId', selectedId)
+			}
+		}
+		self.checkAllFeedbacks()
 		//build temp array for CHOICES_MEDIALISTS, and then compare to existing array to see if we need to update
-		const tempChoicesElements = medialists.map((m: any) => {
+		const tempChoicesElements = medialists.map((m) => {
 			return { id: m.Id, label: m.Name }
 		})
-
 		if (tempChoicesElements.length === 0) {
 			tempChoicesElements.push({ id: 'None', label: 'None' })
 		}
-
 		//only update if choices have changed
 		if (JSON.stringify(self.CHOICES_MEDIALISTS) !== JSON.stringify(tempChoicesElements)) {
 			self.CHOICES_MEDIALISTS = tempChoicesElements
 			self.updateActions()
 			self.updateFeedbacks()
 		}
-
 		const allMediaChoices = await buildMedialistsMediaChoices(self, medialists)
 		if (JSON.stringify(self.CHOICES_MEDIALISTS_MEDIA) !== JSON.stringify(allMediaChoices)) {
 			self.CHOICES_MEDIALISTS_MEDIA = allMediaChoices
@@ -465,78 +591,59 @@ async function pollMedialist(self: MulticamInstance) {
 			self.updateFeedbacks()
 		}
 	}
-
-	//get selected medialist
-	//api/v3/medialist/selected
-
-	const selectedMedialist = await fetchData(self, '/api/v3/medialist/selected')
-	if (selectedMedialist && selectedMedialist !== 'Application not launched!') {
-		self.MEDIALIST_SELECTED = selectedMedialist
-		let nextSelectedMedia: { id: string; label: string }[]
-		if (selectedMedialist.Items && selectedMedialist.Items.length > 0) {
-			const mlName = String(selectedMedialist.Name ?? '')
-			nextSelectedMedia = selectedMedialist.Items.map((m: any) => ({
-				id: m.Id,
-				label: `${mlName} - ${m.MediaName}`,
-			}))
-			if (nextSelectedMedia.length === 0) {
-				nextSelectedMedia.push({ id: 'None', label: 'None' })
-			}
+	if (includeSignalRState) {
+		// Selected medialist/media are event-driven while SignalR is connected.
+		const selectedMedialist = await fetchData(self, '/api/v3/medialist/selected')
+		if (selectedMedialist && typeof selectedMedialist === 'object' && !Array.isArray(selectedMedialist)) {
+			self.MEDIALIST_SELECTED = selectedMedialist
+			updateSelectedMedialistChoices(self, selectedMedialist)
+			await updateVariable(self, 'medialistSelectedName', selectedMedialist.Name || '')
+			await updateVariable(self, 'medialistSelectedId', selectedMedialist.Id || '')
 		} else {
-			nextSelectedMedia = [{ id: 'None', label: 'None' }]
+			self.log('debug', 'Unable to fetch selected medialist, application not launched')
 		}
-		if (JSON.stringify(self.CHOICES_MEDIALIST_SELECTED_MEDIA) !== JSON.stringify(nextSelectedMedia)) {
-			self.CHOICES_MEDIALIST_SELECTED_MEDIA = nextSelectedMedia
-			self.updateActions()
-			self.updateFeedbacks()
+		const selectedMedia = await fetchData(self, '/api/v3/medialist/selected/media')
+		if (selectedMedia && selectedMedia !== 'Application not launched!') {
+			self.MEDIALIST_SELECTED_MEDIA = selectedMedia
+			await updateVariable(self, 'medialistSelectedMedia', JSON.stringify(selectedMedia))
+			await updateVariable(self, 'medialistSelectedMediaName', selectedMedia.MediaName ?? selectedMedia.Name ?? '')
+			await updateVariable(self, 'medialistSelectedMediaId', selectedMedia.Id ?? '')
+		} else {
+			self.log('debug', 'Unable to fetch selected media, application not launched')
 		}
-		await updateVariable(self, 'medialistSelectedName', selectedMedialist.Name || '')
-		await updateVariable(self, 'medialistSelectedId', selectedMedialist.Id || '')
-	} else {
-		self.log('debug', 'Unable to fetch selected medialist, application not launched')
-	}
-
-	//get selected media in selected medialist
-	//api/v3/medialist/selected/media
-
-	const selectedMedia = await fetchData(self, '/api/v3/medialist/selected/media')
-	if (selectedMedia && selectedMedia !== 'Application not launched!') {
-		self.MEDIALIST_SELECTED_MEDIA = selectedMedia
-		await updateVariable(self, 'medialistSelectedMedia', JSON.stringify(selectedMedia))
-	} else {
-		self.log('debug', 'Unable to fetch selected media, application not launched')
 	}
 }
-
 async function pollPublisher(_self: MulticamInstance) {
 	//self.log('info', 'Polling publisher - not yet implemented')
 }
-
 async function pollRadio(_self: MulticamInstance) {
 	//self.log('info', 'Polling radio - not yet implemented')
 }
-
 async function pollRecording(_self: MulticamInstance) {
 	//self.log('info', 'Polling recording - not yet implemented')
 }
-
-async function pollScenes(self: MulticamInstance) {
+async function pollScenes(self: MulticamInstance, includeSignalRState: boolean = true) {
 	self.log('debug', 'Polling scenes')
-
 	//get scenes files
 	const sceneFiles = await fetchData(self, '/api/v2/scenes/files')
-	if (sceneFiles && sceneFiles !== 'Application not launched!') {
+	if (Array.isArray(sceneFiles)) {
 		self.SCENE_FILES = sceneFiles
-
+		if (!includeSignalRState) {
+			const selectedId = String(self.SCENES_FILE_SELECTED?.Id ?? self.SCENES_FILE_SELECTED?.id ?? '')
+			const selected = sceneFiles.find((file) => String(file?.Id ?? file?.id ?? '') === selectedId)
+			if (selected) {
+				self.SCENES_FILE_SELECTED = selected
+				await updateVariable(self, 'sceneSelectedFileName', selected.Name ?? selected.name ?? '')
+				await updateVariable(self, 'sceneSelectedFileId', selectedId)
+			}
+		}
 		//build CHOICES_SCENE_FILES
-		const choices = sceneFiles.map((f: any) => {
+		const choices = sceneFiles.map((f) => {
 			return { id: f.Id, label: f.Name }
 		})
-
 		if (choices.length === 0) {
 			choices.push({ id: 'None', label: 'None' })
 		}
-
 		//only update if choices have changed
 		if (JSON.stringify(self.CHOICES_SCENES_FILES) !== JSON.stringify(choices)) {
 			self.CHOICES_SCENES_FILES = choices
@@ -546,39 +653,36 @@ async function pollScenes(self: MulticamInstance) {
 	} else {
 		self.log('debug', 'Unable to fetch scene files, application not launched')
 	}
-
-	//get selected secenes file
-	const selectedSceneFile = await fetchData(self, '/api/v2/scenes/selected')
-	if (selectedSceneFile && selectedSceneFile !== 'Application not launched!') {
-		self.SCENES_FILE_SELECTED = selectedSceneFile
-		await updateVariable(self, 'sceneSelectedFileName', selectedSceneFile.Name || '')
-		await updateVariable(self, 'sceneSelectedFileId', selectedSceneFile.Id || '')
-	} else {
-		self.log('debug', 'Unable to fetch selected scene file, application not launched')
+	if (includeSignalRState) {
+		const selectedSceneFile = await fetchData(self, '/api/v2/scenes/selected')
+		if (selectedSceneFile && typeof selectedSceneFile === 'object' && !Array.isArray(selectedSceneFile)) {
+			self.SCENES_FILE_SELECTED = selectedSceneFile
+			await updateVariable(self, 'sceneSelectedFileName', selectedSceneFile.Name || '')
+			await updateVariable(self, 'sceneSelectedFileId', selectedSceneFile.Id || '')
+		} else {
+			self.log('debug', 'Unable to fetch selected scene file, application not launched')
+		}
 	}
-
 	//get selected scenes file content
 	const selectedSceneFileContent = await fetchData(self, '/api/v2/scenes/selected/scenes')
-	if (selectedSceneFileContent && selectedSceneFileContent !== 'Application not launched!') {
-		if (selectedSceneFileContent.status && selectedSceneFileContent.status === 404) {
-			self.SCENES_FILE_SELECTED_SCENES = []
-			self.SCENES_FILE_SELECTED_SCENES = [{ Id: 'None', Name: 'None' }]
-			//log the error - .detail
-			self.log('debug', `Scenes file content error: ${selectedSceneFileContent.detail || 'Unknown error'}`)
-			return
-		}
-
+	if (Array.isArray(selectedSceneFileContent)) {
 		self.SCENES_FILE_SELECTED_SCENES = selectedSceneFileContent
-
+		if (!includeSignalRState) {
+			const selectedId = self.SCENES_FILE_SELECTED_SCENE_ID
+			const selected = selectedSceneFileContent.find((scene) => String(scene?.Id ?? scene?.id ?? '') === selectedId)
+			if (selected) {
+				self.SCENES_FILE_SELECTED_SCENE = selected
+				await updateVariable(self, 'sceneSelectedSceneName', selected.Name ?? selected.name ?? '')
+				await updateVariable(self, 'sceneSelectedSceneId', selectedId)
+			}
+		}
 		//build CHOICES_SCENES_FILE_SELECTED_SCENES
-		const choices = selectedSceneFileContent.map((s: any) => {
+		const choices = selectedSceneFileContent.map((s) => {
 			return { id: s.Id, label: s.Name }
 		})
-
 		if (choices.length === 0) {
 			choices.push({ id: 'None', label: 'None' })
 		}
-
 		//only update if choices have changed
 		if (JSON.stringify(self.CHOICES_SCENES_FILE_SELECTED_SCENES) !== JSON.stringify(choices)) {
 			self.CHOICES_SCENES_FILE_SELECTED_SCENES = choices
@@ -588,300 +692,195 @@ async function pollScenes(self: MulticamInstance) {
 	} else {
 		self.log('debug', 'Unable to fetch selected scene file content, application not launched')
 	}
-
-	//get selected scene
-	const selectedScene = await fetchData(self, '/api/v2/scenes/selected/livescene')
-	if (selectedScene && selectedScene !== 'Application not launched!') {
-		self.SCENES_FILE_SELECTED_SCENE = selectedScene
-		self.SCENES_FILE_SELECTED_SCENE_ID = selectedScene.Id || ''
-		await updateVariable(self, 'sceneSelectedSceneName', selectedScene.Name || '')
-		await updateVariable(self, 'sceneSelectedSceneId', selectedScene.Id || '')
-	} else {
-		self.log('debug', 'Unable to fetch selected scene, application not launched')
+	if (includeSignalRState) {
+		const selectedScene = await fetchData(self, '/api/v2/scenes/selected/livescene')
+		if (selectedScene && typeof selectedScene === 'object' && !Array.isArray(selectedScene)) {
+			self.SCENES_FILE_SELECTED_SCENE = selectedScene
+			self.SCENES_FILE_SELECTED_SCENE_ID = selectedScene.Id || ''
+			await updateVariable(self, 'sceneSelectedSceneName', selectedScene.Name || '')
+			await updateVariable(self, 'sceneSelectedSceneId', selectedScene.Id || '')
+		} else {
+			self.log('debug', 'Unable to fetch selected scene, application not launched')
+		}
 	}
 }
-
-async function pollStreaming(self: MulticamInstance) {
+async function pollStreaming(self: MulticamInstance, includeSignalRState: boolean = true) {
+	if (!includeSignalRState) return
 	self.log('debug', 'Polling streaming')
 	const streamingCatalogs = await fetchData(self, '/api/v2/streaming/catalogs')
-	if (streamingCatalogs) {
-		if (JSON.stringify(self.CHOICES_STREAMING_CATALOGS) !== JSON.stringify(streamingCatalogs)) {
-			self.CHOICES_STREAMING_CATALOGS = streamingCatalogs.map((c: any) => ({ id: c.Id, label: c.Name }))
+	if (Array.isArray(streamingCatalogs)) {
+		const choices = streamingCatalogs.map((c) => ({ id: String(c.Id), label: String(c.Name ?? c.Id) }))
+		if (JSON.stringify(self.CHOICES_STREAMING_CATALOGS) !== JSON.stringify(choices)) {
+			self.CHOICES_STREAMING_CATALOGS = choices
 			self.updateActions()
 		}
 	}
-
+	const selectedCatalog = await fetchData(self, '/api/v2/streaming/selected')
+	if (selectedCatalog && typeof selectedCatalog === 'object' && !Array.isArray(selectedCatalog)) {
+		self.STREAMING_CATALOG_SELECTED = selectedCatalog
+		await updateVariable(self, 'streamingSelectedCatalog', selectedCatalog.Name ?? '')
+		await updateVariable(self, 'streamingSelectedCatalogId', selectedCatalog.Id ?? '')
+	}
 	const streamingProfiles = await fetchData(self, '/api/v2/streaming/selected/profiles')
-	if (streamingProfiles) {
-		if (JSON.stringify(self.CHOICES_STREAMING_PROFILES) !== JSON.stringify(streamingProfiles)) {
-			self.CHOICES_STREAMING_PROFILES = streamingProfiles.map((p: any) => ({ id: p.Id, label: p.Name }))
+	if (Array.isArray(streamingProfiles)) {
+		self.STREAMING_PROFILES = streamingProfiles
+		const choices = streamingProfiles.map((p) => ({ id: String(p.Id), label: String(p.Name ?? p.Id) }))
+		if (JSON.stringify(self.CHOICES_STREAMING_PROFILES) !== JSON.stringify(choices)) {
+			self.CHOICES_STREAMING_PROFILES = choices
 			self.updateActions()
 		}
+		const activeProfiles = streamingProfiles.filter((profile) => profile?.IsStarted)
+		await updateVariable(self, 'streamingActiveProfiles', activeProfiles.map((profile) => profile.Name).join(', '))
+		await updateVariable(self, 'streamingActiveProfileCount', activeProfiles.length)
 	}
 }
-
 async function pollStudio(_self: MulticamInstance) {
 	//self.log('info', 'Polling studio - not yet implemented')
 }
-
-async function pollTitler(self: MulticamInstance) {
-	//get titler files
+async function pollTitler(self: MulticamInstance, includeSignalRState: boolean = true) {
+	let needsUpdate = false
 	const titlerFiles = await fetchData(self, '/api/v2/titler/files')
-	if (titlerFiles) {
+	if (Array.isArray(titlerFiles)) {
 		self.TITLER_FILES = titlerFiles
-		self.checkFeedbacks()
-
-		//console.log('titler files', titlerFiles)
-
-		//build temp array for CHOICES_TITLER_FILES, and then compare to existing array to see if we need to update
-		const tempChoicesFiles: any[] = []
-		for (const file of titlerFiles) {
-			tempChoicesFiles.push({ id: file.Id, label: file.Name })
+		if (!includeSignalRState) {
+			const selectedId = String(self.TITLER_FILE_SELECTED?.Id ?? self.TITLER_FILE_SELECTED?.id ?? '')
+			const selected = titlerFiles.find((file) => String(file?.Id ?? file?.id ?? '') === selectedId)
+			if (selected) {
+				self.TITLER_FILE_SELECTED = selected
+				await updateVariable(self, 'titlerSelectedFileName', selected.Name ?? selected.name ?? '')
+				await updateVariable(self, 'titlerSelectedFileId', selectedId)
+			}
+			for (const file of titlerFiles) file.IsSelected = String(file.Id ?? file.id ?? '') === selectedId
 		}
-
-		if (JSON.stringify(self.CHOICES_TITLER_FILES) !== JSON.stringify(tempChoicesFiles)) {
-			self.CHOICES_TITLER_FILES = tempChoicesFiles
-			self.updateActions()
-			self.updateFeedbacks()
-		}
-	}
-
-	//get selected titler file
-	const selectedTitlerFile = await fetchData(self, '/api/v2/titler/selected')
-	if (selectedTitlerFile && selectedTitlerFile !== 'Application not launched!') {
-		//update name and id
-		await updateVariable(self, 'titlerSelectedFileName', selectedTitlerFile.Name || '')
-		await updateVariable(self, 'titlerSelectedFileId', selectedTitlerFile.Id || '')
-		self.log('debug', `Selected titler file ID: ${selectedTitlerFile.Id}`)
-		self.log('debug', `Selected titler file Name: ${selectedTitlerFile.Name}`)
-	} else {
-		await updateVariable(self, 'titlerSelectedFileName', 'None')
-		await updateVariable(self, 'titlerSelectedFileId', 'None')
-		self.log('debug', 'Unable to fetch selected titler file, application not launched')
-	}
-
-	//get selected titler file elements
-	const selectedTitlerFileElements = await fetchData(self, '/api/v2/titler/selected/elements')
-	if (selectedTitlerFileElements && selectedTitlerFileElements !== 'Application not launched!') {
-		if (selectedTitlerFileElements.status && selectedTitlerFileElements.status === 404) {
-			self.log('debug', 'No elements found for selected titler file')
-			return
-		}
-
-		let needsUpdate = false
-
-		//build temp array for CHOICES_TITLER_ELEMENTS, and then compare to existing array to see if we need to update
-		const tempChoicesElements: any[] = []
-		for (const element of selectedTitlerFileElements) {
-			tempChoicesElements.push({ id: element.Id, label: element.Name })
-		}
-
-		if (JSON.stringify(self.CHOICES_TITLER_ELEMENTS) !== JSON.stringify(tempChoicesElements)) {
-			self.CHOICES_TITLER_ELEMENTS = tempChoicesElements
+		const choices = titlerFiles.map((file) => ({ id: String(file.Id), label: String(file.Name ?? file.Id) }))
+		if (choices.length === 0) choices.push({ id: 'none', label: 'None' })
+		if (JSON.stringify(self.CHOICES_TITLER_FILES) !== JSON.stringify(choices)) {
+			self.CHOICES_TITLER_FILES = choices
 			needsUpdate = true
 		}
-
-		//loop through elements and grab each element's content via /api/v2/titler/selected/elements/{elementId}/speaker/entries
-		for (const element of selectedTitlerFileElements) {
-			if (self.config.verbose) {
-				self.log('debug', `Processing element ${element.Id} (${element.Name}) of type ${element.ElementType}`)
-			}
-
-			self.log('debug', `Processing element ${element.Id} (${element.Name}) of type ${element.ElementType}`)
-
-			if (element.ElementType == 'Speaker') {
-				if (self.config.verbose) {
-					self.log('debug', `Fetching speaker entries for element ${element.Id} (${element.Name})`)
-				}
-
-				// Build CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS
-				const tempSpeakerChoicesRows: any[] = []
-
-				const elementSpeakerEntries = await fetchData(
-					self,
-					`/api/v2/titler/selected/elements/${element.Id}/speaker/entries`,
-				)
-				if (elementSpeakerEntries) {
-					if (elementSpeakerEntries.status && elementSpeakerEntries.status === 404) {
-						element.SpeakerEntries = []
-						//log the error - .detail
-						self.log(
-							'debug',
-							`Titler element speaker entries error for element ${element.Id}: ${elementSpeakerEntries.detail || 'Unknown error'}`,
-						)
-					} else {
-						//append the speaker entries to the element object
-						element.SpeakerEntries = elementSpeakerEntries
-
-						for (const entry of elementSpeakerEntries) {
-							if (entry.Entries && typeof entry.Entries === 'object') {
-								const entriesLabel = Object.entries(entry.Entries)
-									.map(([k, v]) => `${k}: ${v}`)
-									.join(', ')
-
-								tempSpeakerChoicesRows.push({
-									id: `${element.Id}_speaker_${entry.Id}`,
-									label: entriesLabel,
-								})
-							} /* else {
-								// fallback: no Entries
-								tempSpeakerChoicesRows.push({
-									id: `${element.Id}_speaker`,
-									label: '(no entries)',
-								})
-							}*/
-						}
-					}
-				}
-
-				//if tempSpeakerChoicesRows is empty, add a 'None' choice
-				if (tempSpeakerChoicesRows.length === 0) {
-					tempSpeakerChoicesRows.push({ id: 'None', label: 'None' })
-				}
-
-				if (JSON.stringify(self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS) !== JSON.stringify(tempSpeakerChoicesRows)) {
-					self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS = tempSpeakerChoicesRows
-					needsUpdate = true
-				}
-
-				//get element speaker live row id via /api/v2/titler/selected/elements/{elementId}/speaker/entries/live
-				const elementLiveSpeakerRowId = await fetchData(
-					self,
-					`/api/v2/titler/selected/elements/${element.Id}/speaker/entries/live`,
-				)
-				if (elementLiveSpeakerRowId) {
-					element.LiveSpeakerRowId = elementLiveSpeakerRowId.Id || ''
-				}
-			} else if (element.ElementType == 'Panel') {
-				if (self.config.verbose) {
-					self.log('debug', `Fetching panel entries for element ${element.Id} (${element.Name})`)
-				}
-
-				//build CHOICES_TITLER_ELEMENTS_PANEL_ROWS
-				const tempPanelChoicesRows: any[] = []
-
-				//get each element's panel entries via /api/v2/titler/selected/elements/{elementId}/panel/entries
-				const elementPanelEntries = await fetchData(
-					self,
-					`/api/v2/titler/selected/elements/${element.Id}/panel/entries`,
-				)
-				if (elementPanelEntries) {
-					if (elementPanelEntries.status && elementPanelEntries.status === 404) {
-						element.PanelEntries = []
-						//log the error - .detail
-						self.log(
-							'debug',
-							`Titler element panel entries error for element ${element.Id}: ${elementPanelEntries.detail || 'Unknown error'}`,
-						)
-					} else {
-						//append the panel entries to the element object
-						element.PanelEntries = elementPanelEntries
-
-						for (const entry of elementPanelEntries) {
-							if (entry.Entries && typeof entry.Entries === 'object') {
-								const entriesLabel = Object.entries(entry.Entries)
-									.map(([k, v]) => `${k}: ${v}`)
-									.join(', ')
-
-								tempPanelChoicesRows.push({
-									id: `${element.Id}_panel_${entry.Id}`,
-									label: entriesLabel,
-								})
-							} /* else {
-								// fallback: no Entries
-								tempPanelChoicesRows.push({
-									id: `${element.Id}_panel`,
-									label: '(no entries)',
-								})
-							}*/
-						}
-					}
-				}
-
-				//if tempPanelChoicesRows is empty, add a 'None' choice
-				if (tempPanelChoicesRows.length === 0) {
-					tempPanelChoicesRows.push({ id: 'None', label: 'None' })
-				}
-
-				if (JSON.stringify(self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS) !== JSON.stringify(tempPanelChoicesRows)) {
-					self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS = tempPanelChoicesRows
-					needsUpdate = true
-				}
-
-				//get element speaker live row id via /api/v2/titler/selected/elements/{elementId}/panel/entries/live
-				const elementLivePanelRowId = await fetchData(
-					self,
-					`/api/v2/titler/selected/elements/${element.Id}/panel/entries/live`,
-				)
-				if (elementLivePanelRowId) {
-					element.LivePanelRowId = elementLivePanelRowId.Id || ''
-				}
-			}
+	}
+	if (includeSignalRState) {
+		const selectedTitlerFile = await fetchData(self, '/api/v2/titler/selected')
+		if (selectedTitlerFile && typeof selectedTitlerFile === 'object' && !Array.isArray(selectedTitlerFile)) {
+			self.TITLER_FILE_SELECTED = selectedTitlerFile
+			await updateVariable(self, 'titlerSelectedFileName', selectedTitlerFile.Name || '')
+			await updateVariable(self, 'titlerSelectedFileId', selectedTitlerFile.Id || '')
+			for (const file of self.TITLER_FILES) file.IsSelected = String(file.Id) === String(selectedTitlerFile.Id)
+		} else {
+			self.TITLER_FILE_SELECTED = {}
+			await updateVariable(self, 'titlerSelectedFileName', 'None')
+			await updateVariable(self, 'titlerSelectedFileId', 'None')
 		}
-
-		self.TITLER_SELECTED_FILE_ELEMENTS = selectedTitlerFileElements
-
+	}
+	const elements = await fetchData(self, '/api/v2/titler/selected/elements')
+	if (!Array.isArray(elements)) {
 		if (needsUpdate) {
 			self.updateActions()
 			self.updateFeedbacks()
 		}
-
-		self.checkFeedbacks()
-	} else {
-		self.log('debug', 'Unable to fetch selected titler file elements, application not launched')
+		return
 	}
+	const elementChoices = elements.map((element) => ({
+		id: String(element.Id),
+		label: String(element.Name ?? element.Id),
+	}))
+	if (elementChoices.length === 0) elementChoices.push({ id: 'none', label: 'None' })
+	if (JSON.stringify(self.CHOICES_TITLER_ELEMENTS) !== JSON.stringify(elementChoices)) {
+		self.CHOICES_TITLER_ELEMENTS = elementChoices
+		needsUpdate = true
+	}
+	const rowBuckets = await Promise.all(
+		elements.map(async (element) => {
+			const elementId = encodeURIComponent(String(element.Id))
+			const kind = String(element.ElementType ?? '').toLowerCase()
+			if (kind !== 'speaker' && kind !== 'panel') return { speaker: [], panel: [] }
+			const [entries, live] = await Promise.all([
+				fetchData(self, `/api/v2/titler/selected/elements/${elementId}/${kind}/entries`),
+				fetchData(self, `/api/v2/titler/selected/elements/${elementId}/${kind}/entries/live`),
+			])
+			const validEntries = Array.isArray(entries) ? entries : []
+			if (kind === 'speaker') {
+				element.SpeakerEntries = validEntries
+				element.LiveSpeakerRowId = live && typeof live === 'object' ? String(live.Id ?? '') : ''
+			} else {
+				element.PanelEntries = validEntries
+				element.LivePanelRowId = live && typeof live === 'object' ? String(live.Id ?? '') : ''
+			}
+			const choices = validEntries.map((entry) => {
+				const entryValues = entry?.Entries && typeof entry.Entries === 'object' ? Object.values(entry.Entries) : []
+				const valuesLabel = entryValues
+					.map((value) => String(value))
+					.filter(Boolean)
+					.join(' - ')
+				return {
+					id: `${element.Id}_${kind}_${entry.Id}`,
+					label: `${element.Name ?? element.Id} - ${valuesLabel || entry.Id}`,
+				}
+			})
+			return kind === 'speaker' ? { speaker: choices, panel: [] } : { speaker: [], panel: choices }
+		}),
+	)
+	const speakerChoices = rowBuckets.flatMap((bucket) => bucket.speaker)
+	const panelChoices = rowBuckets.flatMap((bucket) => bucket.panel)
+	if (speakerChoices.length === 0) speakerChoices.push({ id: 'none', label: 'None' })
+	if (panelChoices.length === 0) panelChoices.push({ id: 'none', label: 'None' })
+	if (JSON.stringify(self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS) !== JSON.stringify(speakerChoices)) {
+		self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS = speakerChoices
+		needsUpdate = true
+	}
+	if (JSON.stringify(self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS) !== JSON.stringify(panelChoices)) {
+		self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS = panelChoices
+		needsUpdate = true
+	}
+	self.TITLER_SELECTED_FILE_ELEMENTS = elements
+	if (needsUpdate) {
+		self.updateActions()
+		self.updateFeedbacks()
+	}
+	self.checkAllFeedbacks()
 }
-
 async function pollVideo(_self: MulticamInstance) {
 	//self.log('info', 'Polling video - not yet implemented')
 }
-
 export async function updateVariable(self: MulticamInstance, varName: string, value: unknown): Promise<void> {
 	const variableObj: any = {}
 	variableObj[varName] = value
 	self.setVariableValues(variableObj)
 }
-
-async function fetchData(self: MulticamInstance, endpoint: string, method?: string, payload?: any): Promise<any> {
+export async function fetchData(
+	self: MulticamInstance,
+	endpoint: string,
+	method?: string,
+	payload?: unknown,
+): Promise<any> {
 	try {
 		if (self.config.host && self.config.port) {
 			const url = `http://${self.config.host}:${self.config.port}${endpoint}`
-
 			if (self.config.verbose) {
 				self.log('debug', `Fetching: ${url}`)
 			}
-
 			if (!method) {
 				method = 'GET'
 			}
-
 			const headers: any = {
 				'Content-Type': 'application/json',
 			}
-
 			//if api key is specified, add it to headers
-			if (self.config.specifyApiKey && self.config.apiKey) {
-				headers['x-apikey'] = `${self.config.apiKey}`
+			if (self.config.specifyApiKey && self.secrets.apiKey) {
+				headers['x-apikey'] = self.secrets.apiKey
 			}
-
 			let body: string | undefined = undefined
-
-			// If payload is provided, include it in the request
-			if (payload) {
-				method = 'POST' //override to POST if we have a payload
+			// If payload is provided, include it in the request without changing the requested method.
+			if (payload !== undefined) {
 				body = JSON.stringify(payload)
 			}
-
 			const response = await fetch(url, {
 				method: method,
 				headers: headers,
 				body: body,
 			})
-
 			const contentType = response.headers.get('content-type') || ''
-
 			const raw = await response.text()
-
 			if (contentType.includes('application/json') || contentType.includes('application/problem+json')) {
 				const parsed = JSON.parse(raw)
 				markFetchSucceeded(self)
@@ -904,4 +903,589 @@ async function fetchData(self: MulticamInstance, endpoint: string, method?: stri
 		}
 		return null
 	}
+}
+
+// Additional HTTP API state polling
+type FetchData = (self: MulticamInstance, endpoint: string, method?: string, payload?: unknown) => Promise<any>
+type UpdateVariable = (self: MulticamInstance, variableId: string, value: unknown) => Promise<void>
+
+type UpdateFlags = {
+	actions: boolean
+	feedbacks: boolean
+}
+
+const NONE_CHOICE: DropdownChoice[] = [{ id: 'none', label: 'None' }]
+
+function isRecord(value: unknown): value is Record<string, any> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isProblem(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		typeof value.status === 'number' &&
+		(typeof value.detail === 'string' || typeof value.title === 'string')
+	)
+}
+
+function choicesOrNone(choices: DropdownChoice[]): DropdownChoice[] {
+	return choices.length > 0 ? choices : NONE_CHOICE
+}
+
+function updateChoices(
+	current: DropdownChoice[],
+	next: DropdownChoice[],
+	assign: (choices: DropdownChoice[]) => void,
+	flags: UpdateFlags,
+	feedbacks: boolean = false,
+): void {
+	if (JSON.stringify(current) === JSON.stringify(next)) return
+	assign(next)
+	flags.actions = true
+	if (feedbacks) flags.feedbacks = true
+}
+
+function compositeId(...parts: (string | number)[]): string {
+	return JSON.stringify(parts.map((part) => `${part}`))
+}
+
+function getRoomCameraIndexes(self: MulticamInstance): number[] {
+	const selectedInputs = Array.isArray(self.ROOM_SELECTED?.Inputs) ? self.ROOM_SELECTED.Inputs : []
+	const roomInputs = selectedInputs.length
+		? selectedInputs
+		: self.ROOMS.flatMap((room: any) => (Array.isArray(room?.Inputs) ? room.Inputs : []))
+	const indexes: number[] = roomInputs
+		.filter((input: any) => input?.Camera && input.Camera.IsPilotable !== false)
+		.map((input: any) => Number(input.Index))
+		.filter((index: number) => Number.isInteger(index) && index >= 0 && index <= 39)
+	return [...new Set<number>(indexes)].sort((a, b) => a - b)
+}
+
+async function pollApiAudio(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+): Promise<void> {
+	const [profiles, selected] = await Promise.all([
+		fetchData(self, '/api/v1/audio/profiles'),
+		fetchData(self, '/api/v1/audio/profiles/selected'),
+	])
+	if (Array.isArray(profiles)) {
+		self.AUDIO_PROFILES = profiles
+		const choices = choicesOrNone(
+			profiles
+				.filter((profile: any) => profile?.Id !== undefined)
+				.map((profile: any) => ({ id: String(profile.Id), label: String(profile.Name ?? profile.Id) })),
+		)
+		updateChoices(self.CHOICES_AUDIO_PROFILES, choices, (value) => (self.CHOICES_AUDIO_PROFILES = value), flags, true)
+		await updateVariable(
+			self,
+			'audioProfiles',
+			profiles
+				.map((profile: any) => profile?.Name)
+				.filter(Boolean)
+				.join(', '),
+		)
+	}
+	if (isRecord(selected) && !isProblem(selected)) {
+		self.AUDIO_PROFILE_SELECTED = selected
+		await updateVariable(self, 'audioSelectedProfile', selected.Name ?? '')
+		await updateVariable(self, 'audioSelectedProfileId', selected.Id ?? '')
+	}
+}
+
+async function pollApiConf(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+): Promise<void> {
+	const [workspace, microphones, dynamism, banks, currentBank, autoTitling] = await Promise.all([
+		fetchData(self, '/api/v2/conf/workspace'),
+		fetchData(self, '/api/v2/conf/microphones'),
+		fetchData(self, '/api/v2/conf/dynamism'),
+		fetchData(self, '/api/v2/conf/presetsbanks'),
+		fetchData(self, '/api/v2/conf/presetsbanks/current'),
+		fetchData(self, '/api/v2/conf/api/conf/autotitling'),
+	])
+
+	if (isRecord(workspace) && !isProblem(workspace) && Array.isArray(workspace.Microphones)) {
+		self.CONF_MICROPHONES = workspace.Microphones
+		const choices = choicesOrNone(
+			workspace.Microphones.filter((microphone: any) => !microphone.IsDisabled).map((microphone: any) => ({
+				id: String(microphone.Number),
+				label: String(microphone.Name ?? `Microphone ${microphone.Number}`),
+			})),
+		)
+		updateChoices(self.CHOICES_CONF_MICROPHONES, choices, (value) => (self.CHOICES_CONF_MICROPHONES = value), flags)
+	}
+	if (isRecord(microphones) && !isProblem(microphones)) {
+		self.CONF_STATE.microphones = microphones
+		await updateVariable(self, 'confAutomationMode', microphones.AutomationMode ?? '')
+		await updateVariable(
+			self,
+			'confActiveMicrophones',
+			Array.isArray(microphones.ActiveMicrophones) ? microphones.ActiveMicrophones.join(', ') : '',
+		)
+	}
+	if (isRecord(dynamism) && !isProblem(dynamism)) {
+		self.CONF_STATE.dynamism = dynamism
+		await updateVariable(self, 'confDynamism', dynamism.Dynamism ?? '')
+	}
+	if (Array.isArray(banks)) {
+		self.CONF_PRESET_BANKS = banks
+		const choices = choicesOrNone(
+			banks.map((bank: any) => ({ id: String(bank.Id), label: String(bank.BankName ?? bank.Id) })),
+		)
+		updateChoices(self.CHOICES_CONF_PRESET_BANKS, choices, (value) => (self.CHOICES_CONF_PRESET_BANKS = value), flags)
+	}
+	if (isRecord(currentBank) && !isProblem(currentBank)) {
+		self.CONF_STATE.currentBank = currentBank
+		await updateVariable(self, 'confPresetBank', currentBank.BankName ?? '')
+		await updateVariable(self, 'confPresetBankId', currentBank.Id ?? '')
+	}
+	if (isRecord(autoTitling) && !isProblem(autoTitling)) {
+		self.CONF_STATE.autoTitling = autoTitling
+		await updateVariable(self, 'confAutoTitling', Boolean(autoTitling.IsEnabled))
+	}
+}
+
+async function pollApiInsitu(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+): Promise<void> {
+	const [tagDetails, tagNames, activeTags, layouts, activeLayout] = await Promise.all([
+		fetchData(self, '/api/insitu/tagsdetails'),
+		fetchData(self, '/api/insitu/tags'),
+		fetchData(self, '/api/insitu/tag/on'),
+		fetchData(self, '/api/insitu/layouts'),
+		fetchData(self, '/api/insitu/activelayout'),
+	])
+	const tags = Array.isArray(tagDetails)
+		? tagDetails
+		: Array.isArray(tagNames)
+			? tagNames.map((name: unknown) => ({ Name: String(name) }))
+			: null
+	if (tags) {
+		self.INSITU_TAGS = tags
+		const choices = choicesOrNone(
+			tags
+				.map((tag: any) => String(tag?.Name ?? ''))
+				.filter(Boolean)
+				.map((name: string) => ({ id: name, label: name })),
+		)
+		updateChoices(self.CHOICES_INSITU_TAGS, choices, (value) => (self.CHOICES_INSITU_TAGS = value), flags, true)
+	}
+	if (Array.isArray(activeTags)) {
+		self.INSITU_ACTIVE_TAGS = activeTags.map((tag: any) => (typeof tag === 'string' ? { Name: tag } : tag))
+		await updateVariable(
+			self,
+			'insituActiveTags',
+			self.INSITU_ACTIVE_TAGS.map((tag: any) => tag?.Name)
+				.filter(Boolean)
+				.join(', '),
+		)
+	}
+	if (Array.isArray(layouts)) {
+		self.INSITU_LAYOUTS = layouts
+		const choices = choicesOrNone(
+			layouts
+				.map((layout: any) => String(layout?.Name ?? ''))
+				.filter(Boolean)
+				.map((name: string) => ({ id: name, label: name })),
+		)
+		updateChoices(self.CHOICES_INSITU_LAYOUTS, choices, (value) => (self.CHOICES_INSITU_LAYOUTS = value), flags, true)
+	}
+	if (isRecord(activeLayout) && !isProblem(activeLayout)) {
+		self.INSITU_ACTIVE_LAYOUT = activeLayout
+		await updateVariable(self, 'insituActiveLayout', activeLayout.Name ?? '')
+	}
+
+	const running = self.RUNNING_APPLICATION.toLowerCase().replace(/\s+/g, '')
+	if (!running.includes('insitu')) return
+	const cameraIndexes = getRoomCameraIndexes(self)
+	const presetBuckets = await Promise.all(
+		cameraIndexes.map(async (cameraIndex) => {
+			const presets = await fetchData(self, `/api/insitu/presets/${cameraIndex}`)
+			return Array.isArray(presets) ? presets : []
+		}),
+	)
+	const presets = presetBuckets.flat()
+	self.INSITU_PRESETS = presets
+	const choices = choicesOrNone(
+		presets.map((preset: any) => ({
+			id: compositeId(preset.CameraIndex, preset.Index),
+			label: `Camera ${Number(preset.CameraIndex) + 1} - Preset ${preset.Index}`,
+		})),
+	)
+	updateChoices(self.CHOICES_INSITU_PRESETS, choices, (value) => (self.CHOICES_INSITU_PRESETS = value), flags)
+}
+
+async function pollPilot(self: MulticamInstance, fetchData: FetchData, flags: UpdateFlags): Promise<void> {
+	if (!self.RUNNING_APPLICATION) return
+	const cameraIndexes = getRoomCameraIndexes(self)
+	const cameraSources = cameraIndexes.map((index) => `CAM${index + 1}`)
+	const buckets = await Promise.all(
+		cameraSources.map(async (camera) => {
+			const sequences = await fetchData(self, `/api/v1/pilot/activebank/${camera}/sequences`)
+			return Array.isArray(sequences) ? sequences.map((sequence: any) => ({ ...sequence, Camera: camera })) : []
+		}),
+	)
+	const sequences = buckets.flat()
+	self.PILOT_SEQUENCES = sequences
+	const choices = choicesOrNone(
+		sequences.map((sequence: any) => ({
+			id: compositeId(sequence.Camera, sequence.Id),
+			label: `${sequence.Camera} - ${sequence.Name ?? sequence.Id}`,
+		})),
+	)
+	updateChoices(self.CHOICES_PILOT_SEQUENCES, choices, (value) => (self.CHOICES_PILOT_SEQUENCES = value), flags)
+}
+
+async function pollApiPublisher(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+	includeSignalRState: boolean = true,
+): Promise<void> {
+	const [recordings, workflows] = await Promise.all([
+		includeSignalRState ? fetchData(self, '/api/publisher/recordings') : Promise.resolve(undefined),
+		fetchData(self, '/api/publisher/workflows'),
+	])
+	if (Array.isArray(recordings)) {
+		self.PUBLISHER_RECORDINGS = recordings
+		const choices = choicesOrNone(
+			recordings.map((recording: any) => ({
+				id: String(recording.Id),
+				label: `${recording.Title ?? recording.FileName ?? `Recording ${recording.Id}`} (${recording.Date ?? recording.Id})`,
+			})),
+		)
+		updateChoices(
+			self.CHOICES_PUBLISHER_RECORDINGS,
+			choices,
+			(value) => (self.CHOICES_PUBLISHER_RECORDINGS = value),
+			flags,
+		)
+		await updateVariable(self, 'publisherRecordingCount', recordings.length)
+	}
+	if (Array.isArray(workflows)) {
+		self.PUBLISHER_WORKFLOWS = workflows
+		const choices = choicesOrNone(
+			workflows
+				.filter((workflow: any) => workflow.IsFullyAutomated)
+				.map((workflow: any) => ({ id: String(workflow.Name), label: String(workflow.Name) })),
+		)
+		updateChoices(
+			self.CHOICES_PUBLISHER_WORKFLOWS,
+			choices,
+			(value) => (self.CHOICES_PUBLISHER_WORKFLOWS = value),
+			flags,
+		)
+	}
+}
+
+async function pollApiRadio(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+): Promise<void> {
+	const [workspace, microphones, dynamism, banks, currentBank, autoTitling, variables] = await Promise.all([
+		fetchData(self, '/api/v2/radio/workspace'),
+		fetchData(self, '/api/v2/radio/microphones'),
+		fetchData(self, '/api/v2/radio/dynamism'),
+		fetchData(self, '/api/v2/radio/presetsbank'),
+		fetchData(self, '/api/v2/radio/presetsbanks/current'),
+		fetchData(self, '/api/v2/radio/api/conf/autotitling'),
+		fetchData(self, '/api/v2/radio/automation/variables'),
+	])
+	if (isRecord(workspace) && !isProblem(workspace) && Array.isArray(workspace.Microphones)) {
+		self.RADIO_MICROPHONES = workspace.Microphones
+		const choices = choicesOrNone(
+			workspace.Microphones.filter((microphone: any) => !microphone.IsDisabled).map((microphone: any) => ({
+				id: String(microphone.Number),
+				label: String(microphone.Name ?? `Microphone ${microphone.Number}`),
+			})),
+		)
+		updateChoices(self.CHOICES_RADIO_MICROPHONES, choices, (value) => (self.CHOICES_RADIO_MICROPHONES = value), flags)
+	}
+	if (isRecord(microphones) && !isProblem(microphones)) {
+		self.RADIO_STATE.microphones = microphones
+		await updateVariable(self, 'radioAutomationMode', microphones.AutomationMode ?? '')
+		await updateVariable(
+			self,
+			'radioActiveMicrophones',
+			Array.isArray(microphones.ActiveMicrophones) ? microphones.ActiveMicrophones.join(', ') : '',
+		)
+	}
+	if (isRecord(dynamism) && !isProblem(dynamism)) {
+		self.RADIO_STATE.dynamism = dynamism
+		await updateVariable(self, 'radioDynamism', dynamism.Dynamism ?? '')
+	}
+	if (Array.isArray(banks)) {
+		self.RADIO_PRESET_BANKS = banks
+		const choices = choicesOrNone(
+			banks.map((bank: any) => ({ id: String(bank.Id), label: String(bank.BankName ?? bank.Id) })),
+		)
+		updateChoices(self.CHOICES_RADIO_PRESET_BANKS, choices, (value) => (self.CHOICES_RADIO_PRESET_BANKS = value), flags)
+	}
+	if (isRecord(currentBank) && !isProblem(currentBank)) {
+		self.RADIO_STATE.currentBank = currentBank
+		await updateVariable(self, 'radioPresetBank', currentBank.BankName ?? '')
+		await updateVariable(self, 'radioPresetBankId', currentBank.Id ?? '')
+	}
+	if (isRecord(autoTitling) && !isProblem(autoTitling)) {
+		self.RADIO_STATE.autoTitling = autoTitling
+		await updateVariable(self, 'radioAutoTitling', Boolean(autoTitling.IsEnabled))
+	}
+	if (isRecord(variables) && !isProblem(variables) && Array.isArray(variables.Variables)) {
+		self.RADIO_AUTOMATION_VARIABLES = variables.Variables
+		await updateVariable(self, 'radioAutomationVariables', JSON.stringify(variables.Variables))
+	}
+}
+
+async function pollApiRecording(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	includeSignalRState: boolean = true,
+): Promise<void> {
+	const liveExtractActive = Boolean(
+		self.RECORDING_LIVE_EXTRACT?.IsInProgress ?? self.RECORDING_LIVE_EXTRACT?.isInProgress,
+	)
+	const [recording, paused, liveExtract] = await Promise.all([
+		includeSignalRState ? fetchData(self, '/api/recording/status') : Promise.resolve(undefined),
+		fetchData(self, '/api/recording/pause'),
+		includeSignalRState || liveExtractActive
+			? fetchData(self, '/api/recording/liveextract')
+			: Promise.resolve(undefined),
+	])
+	if (typeof recording === 'boolean') {
+		self.RECORDING = recording
+		await updateVariable(self, 'recording', recording)
+	}
+	if (typeof paused === 'boolean') {
+		self.RECORDING_PAUSED = paused
+		await updateVariable(self, 'recordingPaused', paused)
+	} else if (typeof paused === 'string') {
+		const normalized = paused.trim().toLowerCase()
+		if (
+			['true', '1', 'paused', 'pause'].includes(normalized) ||
+			['false', '0', 'running', 'recording'].includes(normalized)
+		) {
+			self.RECORDING_PAUSED = ['true', '1', 'paused', 'pause'].includes(normalized)
+			await updateVariable(self, 'recordingPaused', self.RECORDING_PAUSED)
+		}
+	}
+	if (isRecord(liveExtract) && !isProblem(liveExtract)) {
+		self.RECORDING_LIVE_EXTRACT = liveExtract
+		await updateVariable(self, 'recordingLiveExtract', Boolean(liveExtract.IsInProgress))
+		await updateVariable(self, 'recordingLiveExtractSecondsRemaining', liveExtract.SecondsToAutomaticEnd ?? 0)
+	}
+}
+
+async function pollSettings(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+): Promise<void> {
+	const constraints = await fetchData(self, '/api/v1/settings/mediaconstraints')
+	if (isRecord(constraints) && !isProblem(constraints)) {
+		self.MEDIA_CONSTRAINTS = constraints
+		await updateVariable(self, 'mediaConstraints', JSON.stringify(constraints))
+	}
+}
+
+async function pollApiStudio(self: MulticamInstance, fetchData: FetchData, flags: UpdateFlags): Promise<void> {
+	if (!self.RUNNING_APPLICATION.toLowerCase().includes('studio')) return
+	const cameraIndexes = getRoomCameraIndexes(self)
+	const buckets = await Promise.all(
+		cameraIndexes.map(async (cameraIndex) => {
+			const presets = await fetchData(self, `/api/studio/presets/${cameraIndex}`)
+			return Array.isArray(presets) ? presets : []
+		}),
+	)
+	const presets = buckets.flat()
+	self.STUDIO_PRESETS = presets
+	const choices = choicesOrNone(
+		presets.map((preset: any) => ({
+			id: compositeId(preset.CameraIndex, preset.Index),
+			label: `Camera ${Number(preset.CameraIndex) + 1} - Preset ${preset.Index}`,
+		})),
+	)
+	updateChoices(self.CHOICES_STUDIO_PRESETS, choices, (value) => (self.CHOICES_STUDIO_PRESETS = value), flags)
+}
+
+async function pollTitlerStructures(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+): Promise<void> {
+	if (!Array.isArray(self.TITLER_SELECTED_FILE_ELEMENTS)) return
+	const speakers = self.TITLER_SELECTED_FILE_ELEMENTS.filter(
+		(element: any) => String(element?.ElementType ?? '').toLowerCase() === 'speaker',
+	)
+	const panels = self.TITLER_SELECTED_FILE_ELEMENTS.filter(
+		(element: any) => String(element?.ElementType ?? '').toLowerCase() === 'panel',
+	)
+	const tickers = self.TITLER_SELECTED_FILE_ELEMENTS.filter(
+		(element: any) => String(element?.ElementType ?? '').toLowerCase() === 'ticker',
+	)
+	updateChoices(
+		self.CHOICES_TITLER_SPEAKER_ELEMENTS,
+		choicesOrNone(
+			speakers.map((element: any) => ({ id: String(element.Id), label: String(element.Name ?? element.Id) })),
+		),
+		(value) => (self.CHOICES_TITLER_SPEAKER_ELEMENTS = value),
+		flags,
+	)
+	updateChoices(
+		self.CHOICES_TITLER_PANEL_ELEMENTS,
+		choicesOrNone(
+			panels.map((element: any) => ({ id: String(element.Id), label: String(element.Name ?? element.Id) })),
+		),
+		(value) => (self.CHOICES_TITLER_PANEL_ELEMENTS = value),
+		flags,
+	)
+	updateChoices(
+		self.CHOICES_TITLER_TICKER_ELEMENTS,
+		choicesOrNone(
+			tickers.map((element: any) => ({ id: String(element.Id), label: String(element.Name ?? element.Id) })),
+		),
+		(value) => (self.CHOICES_TITLER_TICKER_ELEMENTS = value),
+		flags,
+	)
+
+	await Promise.all([
+		...speakers.map(async (element: any) => {
+			const cached = self.TITLER_ELEMENT_STRUCTURES[`${element.Id}:speaker`]
+			if (cached) {
+				element.SpeakerStructure = cached
+				return
+			}
+			const structure = await fetchData(
+				self,
+				`/api/v2/titler/selected/elements/${encodeURIComponent(String(element.Id))}/speaker/structure`,
+			)
+			if (isRecord(structure) && !isProblem(structure)) {
+				self.TITLER_ELEMENT_STRUCTURES[`${element.Id}:speaker`] = structure
+				element.SpeakerStructure = structure
+				flags.actions = true
+			}
+		}),
+		...panels.map(async (element: any) => {
+			const cached = self.TITLER_ELEMENT_STRUCTURES[`${element.Id}:panel`]
+			if (cached) {
+				element.PanelStructure = cached
+				return
+			}
+			const structure = await fetchData(
+				self,
+				`/api/v2/titler/selected/elements/${encodeURIComponent(String(element.Id))}/panel/structure`,
+			)
+			if (isRecord(structure) && !isProblem(structure)) {
+				self.TITLER_ELEMENT_STRUCTURES[`${element.Id}:panel`] = structure
+				element.PanelStructure = structure
+				flags.actions = true
+			}
+		}),
+		...tickers.map(async (element: any) => {
+			const content = await fetchData(
+				self,
+				`/api/v2/titler/selected/elements/${encodeURIComponent(String(element.Id))}/ticker/content`,
+			)
+			if (isRecord(content) && !isProblem(content)) element.TickerContent = content.Content ?? ''
+		}),
+	])
+	await updateVariable(self, 'titlerElementStructures', JSON.stringify(self.TITLER_ELEMENT_STRUCTURES))
+}
+
+async function pollApiVideo(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	flags: UpdateFlags,
+	includeSignalRState: boolean = true,
+): Promise<void> {
+	const fixedVideoChoices: DropdownChoice[] = [
+		...Array.from({ length: 40 }, (_, index) => ({
+			id: `Source ${index + 1}`,
+			label: `Source ${index + 1}`,
+		})),
+		{ id: 'PC Input', label: 'PC Input' },
+		{ id: 'Medialist', label: 'Medialist' },
+	]
+	updateChoices(
+		self.CHOICES_VIDEO_SOURCES,
+		fixedVideoChoices,
+		(value) => (self.CHOICES_VIDEO_SOURCES = value),
+		flags,
+		true,
+	)
+	if (!includeSignalRState) return
+	const [liveSource, mixer] = await Promise.all([
+		fetchData(self, '/api/video/live'),
+		fetchData(self, '/api/video/mixer'),
+	])
+	if (typeof liveSource === 'string' && liveSource && !liveSource.includes('not initialized')) {
+		self.VIDEO_LIVE_SOURCE = liveSource
+		await updateVariable(self, 'videoLiveSource', liveSource)
+	}
+	if (isRecord(mixer) && !isProblem(mixer) && Array.isArray(mixer.AllSources)) {
+		self.VIDEO_MIXER = mixer
+		await updateVariable(self, 'videoMixerIsComposition', Boolean(mixer.IsComposition))
+	}
+}
+
+async function pollApiState(
+	self: MulticamInstance,
+	fetchData: FetchData,
+	updateVariable: UpdateVariable,
+	includeSignalRState: boolean = true,
+): Promise<void> {
+	const flags: UpdateFlags = { actions: false, feedbacks: false }
+	await pollApiAudio(self, fetchData, updateVariable, flags)
+	const running = self.RUNNING_APPLICATION.toLowerCase().replace(/\s+/g, '')
+	if (running.includes('conf')) await pollApiConf(self, fetchData, updateVariable, flags)
+	if (running.includes('insitu')) await pollApiInsitu(self, fetchData, updateVariable, flags)
+	await pollPilot(self, fetchData, flags)
+	await pollApiPublisher(self, fetchData, updateVariable, flags, includeSignalRState)
+	if (running.includes('radio')) await pollApiRadio(self, fetchData, updateVariable, flags)
+	await pollApiRecording(self, fetchData, updateVariable, includeSignalRState)
+	if (Object.keys(self.MEDIA_CONSTRAINTS).length === 0) await pollSettings(self, fetchData, updateVariable)
+	await pollApiStudio(self, fetchData, flags)
+	await pollTitlerStructures(self, fetchData, updateVariable, flags)
+	await pollApiVideo(self, fetchData, updateVariable, flags, includeSignalRState)
+
+	syncActiveStreamsFromProfiles(self)
+
+	if (flags.actions) self.updateActions()
+	if (flags.feedbacks) self.updateFeedbacks()
+	self.checkAllFeedbacks()
+}
+
+function syncActiveStreamsFromProfiles(self: MulticamInstance): void {
+	self.ACTIVE_STREAMS = self.STREAMING_PROFILES.filter((profile: any) => profile?.IsStarted).map(
+		(profile: any): StreamingProfile => ({
+			id: String(profile.Id),
+			name: String(profile.Name ?? profile.Id),
+			isEnabled: Boolean(profile.IsEnabled),
+			broadcastServerHostname: String(profile.BroadcastServerHostname ?? ''),
+			broadcastStreamID: String(profile.BroadcastStreamID ?? ''),
+			isStarted: Boolean(profile.IsStarted),
+			canBeLaunchedRemotely: Boolean(profile.CanBeLaunchedRemotely),
+			errorMessage: String(profile.ErrorMessage ?? ''),
+		}),
+	)
+	self.setVariableValues({
+		streamingActiveProfiles: self.ACTIVE_STREAMS.map((profile) => profile.name).join(', '),
+		streamingActiveProfileCount: self.ACTIVE_STREAMS.length,
+		streamingAnyActive: self.ACTIVE_STREAMS.length > 0,
+	})
+	self.checkFeedbacks('streaming')
 }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -370,10 +370,10 @@ export function UpdatePresets(self: MulticamInstance): void {
 
 	presets.recordingStart = simplePreset({
 		name: 'RECORDING | Start',
-		text: 'RECORD\nSTART',
+		text: 'REC\nSTART',
 		actions: [presetAction('recordingStart')],
 		feedbacks: [presetFeedback('recording', {}, FEEDBACK_RED)],
-		color: COLOR_BLACK,
+		color: COLOR_WHITE,
 		bgcolor: COLOR_BLACK,
 	})
 	presets.recordingPause = simplePreset({
@@ -386,10 +386,10 @@ export function UpdatePresets(self: MulticamInstance): void {
 	})
 	presets.recordingStop = simplePreset({
 		name: 'RECORDING | Stop',
-		text: 'RECORD\nSTOP',
+		text: 'REC\nSTOP',
 		actions: [presetAction('recordingStop')],
 		feedbacks: [presetFeedback('recording', {}, FEEDBACK_RED)],
-		color: COLOR_BLACK,
+		color: COLOR_WHITE,
 		bgcolor: COLOR_BLACK,
 	})
 	const recordingSourceExpression = localExpression('source')
@@ -407,7 +407,7 @@ export function UpdatePresets(self: MulticamInstance): void {
 			name: 'RECORDING | Stop ISO Source',
 			text: 'ISO STOP\n$(local:source)',
 			actions: [presetAction('recordingIsoStopSource', { camId: recordingSourceExpression })],
-			color: COLOR_BLACK,
+			color: COLOR_WHITE,
 			bgcolor: COLOR_BLACK,
 		}),
 		localVariables: [{ variableType: 'simple', variableName: 'source', startupValue: 'Source 1' }],

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -374,7 +374,7 @@ export function UpdatePresets(self: MulticamInstance): void {
 		actions: [presetAction('recordingStart')],
 		feedbacks: [presetFeedback('recording', {}, FEEDBACK_RED)],
 		color: COLOR_BLACK,
-		bgcolor: COLOR_RED,
+		bgcolor: COLOR_BLACK,
 	})
 	presets.recordingPause = simplePreset({
 		name: 'RECORDING | Pause/Resume',
@@ -382,7 +382,7 @@ export function UpdatePresets(self: MulticamInstance): void {
 		actions: [presetAction('recordingPause')],
 		feedbacks: [presetFeedback('recordingPaused', {}, FEEDBACK_YELLOW)],
 		color: COLOR_BLACK,
-		bgcolor: COLOR_YELLOW,
+		bgcolor: COLOR_WHITE,
 	})
 	presets.recordingStop = simplePreset({
 		name: 'RECORDING | Stop',
@@ -390,7 +390,7 @@ export function UpdatePresets(self: MulticamInstance): void {
 		actions: [presetAction('recordingStop')],
 		feedbacks: [presetFeedback('recording', {}, FEEDBACK_RED)],
 		color: COLOR_BLACK,
-		bgcolor: COLOR_RED,
+		bgcolor: COLOR_BLACK,
 	})
 	const recordingSourceExpression = localExpression('source')
 	presets.recordingIsoStartSource = {
@@ -398,7 +398,7 @@ export function UpdatePresets(self: MulticamInstance): void {
 			name: 'RECORDING | Start ISO Source',
 			text: 'ISO START\n$(local:source)',
 			actions: [presetAction('recordingIsoStartSource', { camId: recordingSourceExpression })],
-			bgcolor: COLOR_GREEN,
+			bgcolor: COLOR_RED,
 		}),
 		localVariables: [{ variableType: 'simple', variableName: 'source', startupValue: 'Source 1' }],
 	}
@@ -408,7 +408,7 @@ export function UpdatePresets(self: MulticamInstance): void {
 			text: 'ISO STOP\n$(local:source)',
 			actions: [presetAction('recordingIsoStopSource', { camId: recordingSourceExpression })],
 			color: COLOR_BLACK,
-			bgcolor: COLOR_RED,
+			bgcolor: COLOR_BLACK,
 		}),
 		localVariables: [{ variableType: 'simple', variableName: 'source', startupValue: 'Source 1' }],
 	}

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,0 +1,588 @@
+import {
+	combineRgb,
+	type CompanionButtonStyleProps,
+	type CompanionFeedbackButtonStyleResult,
+	type CompanionPresetDefinitions,
+	type CompanionPresetGroup,
+	type CompanionPresetSection,
+	type CompanionSimplePresetDefinition,
+	type ExpressionOrValue,
+	type JsonValue,
+	type SomePresetActionEntry,
+	type SomePresetSimpleFeedbackEntry,
+} from '@companion-module/base'
+import type { DropdownChoice, ModuleSchema, MulticamInstance } from './main.js'
+
+type PresetOptionValue = JsonValue | ExpressionOrValue<JsonValue | undefined> | undefined
+type PresetOptions = Record<string, PresetOptionValue>
+
+const COLOR_BLACK = combineRgb(0, 0, 0)
+const COLOR_WHITE = combineRgb(255, 255, 255)
+const COLOR_GREEN = combineRgb(0, 255, 0)
+const COLOR_RED = combineRgb(255, 0, 0)
+const COLOR_YELLOW = combineRgb(255, 255, 0)
+const COLOR_BLUE = combineRgb(0, 0, 255)
+const COLOR_PURPLE = combineRgb(128, 0, 128)
+
+const FEEDBACK_GREEN: CompanionFeedbackButtonStyleResult = { color: COLOR_WHITE, bgcolor: COLOR_GREEN }
+const FEEDBACK_RED: CompanionFeedbackButtonStyleResult = { color: COLOR_BLACK, bgcolor: COLOR_RED }
+const FEEDBACK_YELLOW: CompanionFeedbackButtonStyleResult = { color: COLOR_BLACK, bgcolor: COLOR_YELLOW }
+const FEEDBACK_BLUE: CompanionFeedbackButtonStyleResult = { color: COLOR_WHITE, bgcolor: COLOR_BLUE }
+
+interface SimplePresetOptions {
+	name: string
+	text: string
+	actions?: SomePresetActionEntry<ModuleSchema>[]
+	feedbacks?: SomePresetSimpleFeedbackEntry<ModuleSchema>[]
+	keywords?: string[]
+	color?: number
+	bgcolor?: number
+}
+
+interface ChoicePresetOptions {
+	prefix: string
+	namePrefix: string
+	textPrefix: string
+	choices: DropdownChoice[]
+	actionId: string
+	actionOptions: (choice: DropdownChoice) => PresetOptions
+	feedback?: (choice: DropdownChoice) => SomePresetSimpleFeedbackEntry<ModuleSchema>
+	keywords?: string[]
+	color?: number
+	bgcolor?: number
+}
+
+function presetAction(actionId: string, options: PresetOptions = {}): SomePresetActionEntry<ModuleSchema> {
+	return { actionId, options }
+}
+
+function presetFeedback(
+	feedbackId: string,
+	options: PresetOptions,
+	style: CompanionFeedbackButtonStyleResult,
+	isInverted: boolean = false,
+): SomePresetSimpleFeedbackEntry<ModuleSchema> {
+	return { feedbackId, options, style, ...(isInverted ? { isInverted: true } : {}) }
+}
+
+function simplePreset(options: SimplePresetOptions): CompanionSimplePresetDefinition<ModuleSchema> {
+	const style: CompanionButtonStyleProps = {
+		text: options.text,
+		size: 'auto',
+		color: options.color ?? COLOR_WHITE,
+		bgcolor: options.bgcolor ?? COLOR_BLACK,
+		show_topbar: false,
+	}
+
+	return {
+		type: 'simple',
+		name: options.name,
+		...(options.keywords ? { keywords: options.keywords } : {}),
+		style,
+		steps: options.actions?.length ? [{ down: options.actions, up: [] }] : [],
+		feedbacks: options.feedbacks ?? [],
+	}
+}
+
+function localExpression(variableName: string): ExpressionOrValue<JsonValue | undefined> {
+	return { isExpression: true, value: `$(local:${variableName})` }
+}
+
+function availableChoices(choices: DropdownChoice[]): DropdownChoice[] {
+	const seen = new Set<string>()
+	return choices.filter((choice) => {
+		const id = choice.id.trim()
+		if (!id || id.toLowerCase() === 'none' || seen.has(id)) return false
+		seen.add(id)
+		return true
+	})
+}
+
+function stableChoiceKey(value: string): string {
+	let hash = 2166136261
+	for (let index = 0; index < value.length; index++) {
+		hash ^= value.charCodeAt(index)
+		hash = Math.imul(hash, 16777619)
+	}
+	const slug =
+		value
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, '')
+			.slice(0, 28) || 'choice'
+	return `${slug}_${(hash >>> 0).toString(36)}`
+}
+
+function addChoicePresets(presets: CompanionPresetDefinitions<ModuleSchema>, options: ChoicePresetOptions): string[] {
+	return availableChoices(options.choices).map((choice) => {
+		const presetId = `${options.prefix}_${stableChoiceKey(choice.id)}`
+		presets[presetId] = simplePreset({
+			name: `${options.namePrefix} ${choice.label}`,
+			text: options.textPrefix ? `${options.textPrefix}\n${choice.label}` : choice.label,
+			actions: [presetAction(options.actionId, options.actionOptions(choice))],
+			feedbacks: options.feedback ? [options.feedback(choice)] : [],
+			keywords: options.keywords,
+			color: options.color,
+			bgcolor: options.bgcolor,
+		})
+		return presetId
+	})
+}
+
+function simpleGroup(
+	id: string,
+	name: string,
+	presetIds: string[],
+	description?: string,
+): CompanionPresetGroup<ModuleSchema> | null {
+	if (presetIds.length === 0) return null
+	return { id, type: 'simple', name, presets: presetIds, ...(description ? { description } : {}) }
+}
+
+function addSection(
+	structure: CompanionPresetSection<ModuleSchema>[],
+	id: string,
+	name: string,
+	groups: Array<CompanionPresetGroup<ModuleSchema> | null>,
+): void {
+	const definitions = groups.filter((group): group is CompanionPresetGroup<ModuleSchema> => group !== null)
+	if (definitions.length > 0) structure.push({ id, name, definitions })
+}
+
+export function UpdatePresets(self: MulticamInstance): void {
+	const presets: CompanionPresetDefinitions<ModuleSchema> = {}
+	const structure: CompanionPresetSection<ModuleSchema>[] = []
+
+	presets.systemRefresh = simplePreset({
+		name: 'SYSTEM | Refresh Module Data',
+		text: 'REFRESH\nDATA',
+		actions: [presetAction('manualPoll')],
+		keywords: ['poll', 'refresh', 'sync'],
+		bgcolor: COLOR_BLUE,
+	})
+	presets.systemSignalrStatus = simplePreset({
+		name: 'SYSTEM | SignalR Connection Status',
+		text: 'SIGNALR',
+		feedbacks: [presetFeedback('signalrConnected', {}, FEEDBACK_GREEN)],
+		keywords: ['signalr', 'connection', 'status'],
+	})
+	addSection(structure, 'system', 'System', [
+		simpleGroup('system_status', 'Status and refresh', ['systemRefresh', 'systemSignalrStatus']),
+	])
+
+	presets.applicationAuto = simplePreset({
+		name: 'APPLICATION | Automatic Mode',
+		text: 'APP\nAUTO',
+		actions: [presetAction('applicationSetAutoMode', { isAutoMode: 'true' })],
+		feedbacks: [presetFeedback('applicationAutoMode', { mode: 'Auto' }, FEEDBACK_GREEN)],
+		keywords: ['application', 'automatic', 'mode'],
+	})
+	presets.applicationManual = simplePreset({
+		name: 'APPLICATION | Manual Mode',
+		text: 'APP\nMANUAL',
+		actions: [presetAction('applicationSetAutoMode', { isAutoMode: 'false' })],
+		feedbacks: [presetFeedback('applicationAutoMode', { mode: 'Manual' }, FEEDBACK_YELLOW)],
+		keywords: ['application', 'manual', 'mode'],
+	})
+	presets.applicationRetry = simplePreset({
+		name: 'APPLICATION | Retry Failed Start',
+		text: 'RETRY\nSTART',
+		actions: [presetAction('applicationRetryFailedStart')],
+		bgcolor: COLOR_PURPLE,
+	})
+	const applicationPresets = addChoicePresets(presets, {
+		prefix: 'applicationStart',
+		namePrefix: 'APPLICATION | Start',
+		textPrefix: 'START',
+		choices: self.CHOICES_APPLICATIONS,
+		actionId: 'applicationStart',
+		actionOptions: (choice) => ({ applicationName: choice.id }),
+		keywords: ['application', 'start'],
+		bgcolor: COLOR_GREEN,
+	})
+	addSection(structure, 'application', 'Application', [
+		simpleGroup('application_start', 'Start an application', applicationPresets),
+		simpleGroup('application_modes', 'Automation mode', ['applicationAuto', 'applicationManual']),
+		simpleGroup('application_maintenance', 'Maintenance', ['applicationRetry']),
+	])
+
+	const audioPresets = addChoicePresets(presets, {
+		prefix: 'audioProfile',
+		namePrefix: 'AUDIO | Select Profile',
+		textPrefix: 'AUDIO',
+		choices: self.CHOICES_AUDIO_PROFILES,
+		actionId: 'audioSelectProfile',
+		actionOptions: (choice) => ({ profileId: choice.id }),
+		feedback: (choice) => presetFeedback('audioSelectedProfile', { profileId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['audio', 'mixer', 'profile'],
+	})
+	addSection(structure, 'audio', 'Audio', [simpleGroup('audio_profiles', 'Mixer profiles', audioPresets)])
+
+	presets.composerUntake = simplePreset({
+		name: 'COMPOSER | Untake Composition',
+		text: 'COMPOSITION\nOFF',
+		actions: [presetAction('composerUntakeComposition')],
+		bgcolor: COLOR_RED,
+		color: COLOR_BLACK,
+	})
+	const composerFilePresets = addChoicePresets(presets, {
+		prefix: 'composerFile',
+		namePrefix: 'COMPOSER | Select File',
+		textPrefix: 'COMPOSER',
+		choices: self.CHOICES_COMPOSER_FILES,
+		actionId: 'composerSelectFile',
+		actionOptions: (choice) => ({ composerFileId: choice.id }),
+		feedback: (choice) => presetFeedback('composerSelectedFile', { composerFileId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['composer', 'file'],
+	})
+	const compositionPresets = addChoicePresets(presets, {
+		prefix: 'composerComposition',
+		namePrefix: 'COMPOSER | Select Composition',
+		textPrefix: 'COMPOSITION',
+		choices: self.CHOICES_COMPOSER_COMPOSITIONS,
+		actionId: 'composerSelectComposition',
+		actionOptions: (choice) => ({ compositionId: choice.id }),
+		feedback: (choice) =>
+			presetFeedback('composerSelectedComposition', { composerCompositionId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['composer', 'composition'],
+	})
+	addSection(structure, 'composer', 'Composer', [
+		simpleGroup('composer_files', 'Files', composerFilePresets),
+		simpleGroup('composer_compositions', 'Compositions', compositionPresets),
+		simpleGroup('composer_output', 'Output', ['composerUntake']),
+	])
+
+	presets.confAuto = simplePreset({
+		name: 'CONF | Automatic Microphones',
+		text: 'CONF\nAUTO',
+		actions: [presetAction('confSetMicrophonesAuto')],
+		feedbacks: [presetFeedback('confAutomationMode', { mode: 'Auto' }, FEEDBACK_GREEN)],
+	})
+	presets.confWide = simplePreset({
+		name: 'CONF | Wide Shot',
+		text: 'CONF\nWIDE',
+		actions: [presetAction('confSetMicrophoneWide')],
+		feedbacks: [presetFeedback('confAutomationMode', { mode: 'Wide' }, FEEDBACK_BLUE)],
+	})
+	const confMicrophonePresets = addChoicePresets(presets, {
+		prefix: 'confMicrophone',
+		namePrefix: 'CONF | Manual Microphone',
+		textPrefix: 'CONF MIC',
+		choices: self.CHOICES_CONF_MICROPHONES,
+		actionId: 'confSetMicrophoneManual',
+		actionOptions: (choice) => ({ mic: choice.id }),
+		keywords: ['conference', 'microphone', 'manual'],
+	})
+	addSection(structure, 'conf', 'Conf', [
+		simpleGroup('conf_modes', 'Automation mode', ['confAuto', 'confWide']),
+		simpleGroup('conf_microphones', 'Manual microphones', confMicrophonePresets),
+	])
+
+	const insituTagPresets = addChoicePresets(presets, {
+		prefix: 'insituTag',
+		namePrefix: 'INSITU | Activate Tag',
+		textPrefix: 'TAG',
+		choices: self.CHOICES_INSITU_TAGS,
+		actionId: 'insituTagOn',
+		actionOptions: (choice) => ({ tag: choice.id }),
+		feedback: (choice) => presetFeedback('insituTagActive', { tag: choice.id }, FEEDBACK_GREEN),
+		keywords: ['insitu', 'tag'],
+	})
+	const insituLayoutPresets = addChoicePresets(presets, {
+		prefix: 'insituLayout',
+		namePrefix: 'INSITU | Activate Layout',
+		textPrefix: 'LAYOUT',
+		choices: self.CHOICES_INSITU_LAYOUTS,
+		actionId: 'insituLayoutsOn',
+		actionOptions: (choice) => ({ layout: choice.id }),
+		feedback: (choice) => presetFeedback('insituLayoutActive', { layout: choice.id }, FEEDBACK_GREEN),
+		keywords: ['insitu', 'layout'],
+	})
+	addSection(structure, 'insitu', 'Insitu', [
+		simpleGroup('insitu_tags', 'Tags', insituTagPresets),
+		simpleGroup('insitu_layouts', 'Layouts', insituLayoutPresets),
+	])
+
+	presets.medialistPlay = simplePreset({
+		name: 'MEDIALIST | Play Selected',
+		text: 'MEDIALIST\nPLAY',
+		actions: [presetAction('medialistPlay', { take: true })],
+		bgcolor: COLOR_GREEN,
+	})
+	presets.medialistPause = simplePreset({
+		name: 'MEDIALIST | Pause Selected',
+		text: 'MEDIALIST\nPAUSE',
+		actions: [presetAction('medialistPause')],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_YELLOW,
+	})
+	presets.medialistStop = simplePreset({
+		name: 'MEDIALIST | Stop Selected',
+		text: 'MEDIALIST\nSTOP',
+		actions: [presetAction('medialistStop')],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_RED,
+	})
+	const medialistSelectPresets = addChoicePresets(presets, {
+		prefix: 'medialistSelect',
+		namePrefix: 'MEDIALIST | Select',
+		textPrefix: 'MEDIALIST',
+		choices: self.CHOICES_MEDIALISTS,
+		actionId: 'medialistSelect',
+		actionOptions: (choice) => ({ medialist: choice.id }),
+		feedback: (choice) => presetFeedback('medialistSelected', { medialistId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['medialist', 'select'],
+	})
+	addSection(structure, 'medialist', 'Medialist', [
+		simpleGroup('medialist_select', 'Select a Medialist', medialistSelectPresets),
+		simpleGroup('medialist_transport', 'Selected Medialist transport', [
+			'medialistPlay',
+			'medialistPause',
+			'medialistStop',
+		]),
+	])
+
+	presets.radioAuto = simplePreset({
+		name: 'RADIO | Automatic Microphones',
+		text: 'RADIO\nAUTO',
+		actions: [presetAction('radioEnableAutoMic')],
+		feedbacks: [presetFeedback('radioAutomationMode', { mode: 'Auto' }, FEEDBACK_GREEN)],
+	})
+	presets.radioWide = simplePreset({
+		name: 'RADIO | Wide Shot',
+		text: 'RADIO\nWIDE',
+		actions: [presetAction('radioSetWideShot')],
+		feedbacks: [presetFeedback('radioAutomationMode', { mode: 'Wide' }, FEEDBACK_BLUE)],
+	})
+	const radioMicrophonePresets = addChoicePresets(presets, {
+		prefix: 'radioMicrophone',
+		namePrefix: 'RADIO | Manual Microphone',
+		textPrefix: 'RADIO MIC',
+		choices: self.CHOICES_RADIO_MICROPHONES,
+		actionId: 'radioSetManualMic',
+		actionOptions: (choice) => ({ mic: choice.id }),
+		keywords: ['radio', 'microphone', 'manual'],
+	})
+	addSection(structure, 'radio', 'Radio', [
+		simpleGroup('radio_modes', 'Automation mode', ['radioAuto', 'radioWide']),
+		simpleGroup('radio_microphones', 'Manual microphones', radioMicrophonePresets),
+	])
+
+	presets.recordingStart = simplePreset({
+		name: 'RECORDING | Start',
+		text: 'RECORD\nSTART',
+		actions: [presetAction('recordingStart')],
+		feedbacks: [presetFeedback('recording', {}, FEEDBACK_RED)],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_RED,
+	})
+	presets.recordingPause = simplePreset({
+		name: 'RECORDING | Pause/Resume',
+		text: 'RECORD\nPAUSE',
+		actions: [presetAction('recordingPause')],
+		feedbacks: [presetFeedback('recordingPaused', {}, FEEDBACK_YELLOW)],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_YELLOW,
+	})
+	presets.recordingStop = simplePreset({
+		name: 'RECORDING | Stop',
+		text: 'RECORD\nSTOP',
+		actions: [presetAction('recordingStop')],
+		feedbacks: [presetFeedback('recording', {}, FEEDBACK_RED)],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_RED,
+	})
+	const recordingSourceExpression = localExpression('source')
+	presets.recordingIsoStartSource = {
+		...simplePreset({
+			name: 'RECORDING | Start ISO Source',
+			text: 'ISO START\n$(local:source)',
+			actions: [presetAction('recordingIsoStartSource', { camId: recordingSourceExpression })],
+			bgcolor: COLOR_GREEN,
+		}),
+		localVariables: [{ variableType: 'simple', variableName: 'source', startupValue: 'Source 1' }],
+	}
+	presets.recordingIsoStopSource = {
+		...simplePreset({
+			name: 'RECORDING | Stop ISO Source',
+			text: 'ISO STOP\n$(local:source)',
+			actions: [presetAction('recordingIsoStopSource', { camId: recordingSourceExpression })],
+			color: COLOR_BLACK,
+			bgcolor: COLOR_RED,
+		}),
+		localVariables: [{ variableType: 'simple', variableName: 'source', startupValue: 'Source 1' }],
+	}
+	const recordingSourceValues = availableChoices(self.CHOICES_RECORDING_AUX_SOURCES).map((choice) => ({
+		name: `RECORDING | ${choice.label}`,
+		value: choice.id,
+	}))
+	addSection(structure, 'recording', 'Recording', [
+		simpleGroup('recording_transport', 'Transport', ['recordingStart', 'recordingPause', 'recordingStop']),
+		{
+			id: 'recording_iso_start_sources',
+			type: 'template',
+			name: 'Start one ISO source',
+			presetId: 'recordingIsoStartSource',
+			templateVariableName: 'source',
+			templateValues: recordingSourceValues,
+		},
+		{
+			id: 'recording_iso_stop_sources',
+			type: 'template',
+			name: 'Stop one ISO source',
+			presetId: 'recordingIsoStopSource',
+			templateVariableName: 'source',
+			templateValues: recordingSourceValues,
+		},
+	])
+
+	const sceneFilePresets = addChoicePresets(presets, {
+		prefix: 'sceneFile',
+		namePrefix: 'SCENES | Select File',
+		textPrefix: 'SCENE FILE',
+		choices: self.CHOICES_SCENES_FILES,
+		actionId: 'selectSceneFile',
+		actionOptions: (choice) => ({ fileId: choice.id }),
+		feedback: (choice) => presetFeedback('sceneSelectedFile', { sceneFileId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['scene', 'file'],
+	})
+	const scenePresets = addChoicePresets(presets, {
+		prefix: 'sceneTake',
+		namePrefix: 'SCENES | Take',
+		textPrefix: 'TAKE',
+		choices: self.CHOICES_SCENES_FILE_SELECTED_SCENES,
+		actionId: 'takeScene',
+		actionOptions: (choice) => ({ sceneId: choice.id }),
+		feedback: (choice) => presetFeedback('sceneSelectedScene', { sceneId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['scene', 'take'],
+	})
+	addSection(structure, 'scenes', 'Scenes', [
+		simpleGroup('scene_files', 'Scene files', sceneFilePresets),
+		simpleGroup('scene_take', 'Take a scene', scenePresets),
+	])
+
+	presets.streamingStartAll = simplePreset({
+		name: 'STREAMING | Start All Profiles',
+		text: 'STREAM\nSTART ALL',
+		actions: [presetAction('streamingStartAll')],
+		bgcolor: COLOR_GREEN,
+	})
+	presets.streamingStopAll = simplePreset({
+		name: 'STREAMING | Stop All Profiles',
+		text: 'STREAM\nSTOP ALL',
+		actions: [presetAction('streamingStopAll')],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_RED,
+	})
+	const streamingStartPresets = addChoicePresets(presets, {
+		prefix: 'streamingStart',
+		namePrefix: 'STREAMING | Start',
+		textPrefix: 'STREAM START',
+		choices: self.CHOICES_STREAMING_PROFILES,
+		actionId: 'streamingStartProfile',
+		actionOptions: (choice) => ({ profileId: choice.id }),
+		feedback: (choice) => presetFeedback('streaming', { streamingProfileId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['streaming', 'profile', 'start'],
+	})
+	const streamingStopPresets = addChoicePresets(presets, {
+		prefix: 'streamingStop',
+		namePrefix: 'STREAMING | Stop',
+		textPrefix: 'STREAM STOP',
+		choices: self.CHOICES_STREAMING_PROFILES,
+		actionId: 'streamingStopProfile',
+		actionOptions: (choice) => ({ profileId: choice.id }),
+		feedback: (choice) => presetFeedback('streaming', { streamingProfileId: choice.id }, FEEDBACK_RED),
+		keywords: ['streaming', 'profile', 'stop'],
+		color: COLOR_BLACK,
+		bgcolor: COLOR_RED,
+	})
+	addSection(structure, 'streaming', 'Streaming', [
+		simpleGroup('streaming_all', 'All profiles', ['streamingStartAll', 'streamingStopAll']),
+		simpleGroup('streaming_start', 'Start a profile', streamingStartPresets),
+		simpleGroup('streaming_stop', 'Stop a profile', streamingStopPresets),
+	])
+
+	const titlerFilePresets = addChoicePresets(presets, {
+		prefix: 'titlerFile',
+		namePrefix: 'TITLER | Select File',
+		textPrefix: 'TITLER FILE',
+		choices: self.CHOICES_TITLER_FILES,
+		actionId: 'titlerSelectFile',
+		actionOptions: (choice) => ({ fileId: choice.id }),
+		feedback: (choice) => presetFeedback('titlerSelectedFile', { titlerFileId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['titler', 'file'],
+	})
+	const titlerElementPresets = addChoicePresets(presets, {
+		prefix: 'titlerElement',
+		namePrefix: 'TITLER | Show Element',
+		textPrefix: 'TITLER ON',
+		choices: self.CHOICES_TITLER_ELEMENTS,
+		actionId: 'titlerElementVisible',
+		actionOptions: (choice) => ({ elementId: choice.id, isOn: true, isAnimate: true }),
+		feedback: (choice) => presetFeedback('titlerElementVisible', { titlerElementId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['titler', 'element', 'visible'],
+	})
+	const speakerRowPresets = addChoicePresets(presets, {
+		prefix: 'titlerSpeakerRow',
+		namePrefix: 'TITLER | Set Speaker Row Live',
+		textPrefix: 'SPEAKER',
+		choices: self.CHOICES_TITLER_ELEMENTS_SPEAKER_ROWS,
+		actionId: 'titlerSetSpeakerEntryLiveRow',
+		actionOptions: (choice) => ({ rowId: choice.id, resetTimer: true }),
+		feedback: (choice) =>
+			presetFeedback('titlerElementSpeakerRowLive', { titlerElementRowId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['titler', 'speaker', 'row'],
+	})
+	const panelRowPresets = addChoicePresets(presets, {
+		prefix: 'titlerPanelRow',
+		namePrefix: 'TITLER | Set Panel Row Live',
+		textPrefix: 'PANEL',
+		choices: self.CHOICES_TITLER_ELEMENTS_PANEL_ROWS,
+		actionId: 'titlerSetPanelEntryLiveRow',
+		actionOptions: (choice) => ({ rowId: choice.id, resetTimer: true }),
+		feedback: (choice) =>
+			presetFeedback('titlerElementPanelRowLive', { titlerElementRowId: choice.id }, FEEDBACK_GREEN),
+		keywords: ['titler', 'panel', 'row'],
+	})
+	addSection(structure, 'titler', 'Titler', [
+		simpleGroup('titler_files', 'Files', titlerFilePresets),
+		simpleGroup('titler_elements', 'Show elements', titlerElementPresets),
+		simpleGroup('titler_speaker_rows', 'Speaker rows', speakerRowPresets),
+		simpleGroup('titler_panel_rows', 'Panel rows', panelRowPresets),
+	])
+
+	const videoSourceExpression = localExpression('source')
+	presets.videoLiveSource = {
+		...simplePreset({
+			name: 'VIDEO | Select Live Source',
+			text: '$(local:source)',
+			actions: [presetAction('videoChangeLiveSource', { sourceName: videoSourceExpression })],
+			feedbacks: [presetFeedback('videoLiveSource', { source: videoSourceExpression }, FEEDBACK_RED)],
+			keywords: ['video', 'live', 'source', 'program'],
+		}),
+		localVariables: [{ variableType: 'simple', variableName: 'source', startupValue: 'Source 1' }],
+	}
+	presets.videoRestartOutput = simplePreset({
+		name: 'VIDEO | Restart Output',
+		text: 'RESTART\nOUTPUT',
+		actions: [presetAction('videoRestartOutput')],
+		bgcolor: COLOR_PURPLE,
+	})
+	addSection(structure, 'video', 'Video', [
+		{
+			id: 'video_live_sources',
+			type: 'template',
+			name: 'Live sources',
+			description: 'Select a source; the button turns red while that same source is live.',
+			presetId: 'videoLiveSource',
+			templateVariableName: 'source',
+			templateValues: availableChoices(self.CHOICES_VIDEO_SOURCES).map((choice) => ({
+				name: `VIDEO | ${choice.label}`,
+				value: choice.id,
+			})),
+		},
+		simpleGroup('video_output', 'Output', ['videoRestartOutput']),
+	])
+
+	self.setPresetDefinitions(structure, presets)
+}

--- a/src/signalr.ts
+++ b/src/signalr.ts
@@ -1,282 +1,813 @@
 import * as signalR from '@microsoft/signalr'
-import type { MulticamInstance, StreamingProfile } from './main.js'
+import type { DropdownChoice, MulticamInstance, StreamingProfile } from './main.js'
+import { runPollCycle, runPollScopes, type PollScope } from './polling.js'
 
-function safeStringify(value: any): string {
+export const SIGNALR_STATE_METHODS = [
+	'GetCurrentApplication',
+	'GetRecordings',
+	'GetLastRecording',
+	'GetWorkflows',
+	'GetPublishingJobs',
+	'GetRecordingState',
+	'GetLiveExtractState',
+	'GetStreamingState',
+	'GetUserSelectedMicrophone',
+	'GetIsZoomFeatureEnabled',
+	'GetCropZones',
+] as const
+
+export const SIGNALR_RECEIVER_METHODS = [
+	'OnApplicationInitialized',
+	'OnApplicationInitializedWithDetails',
+	'OnApplicationExited',
+	'OnAutomaticModeChanged',
+	'OnRecordingStarting',
+	'OnRecordStarted',
+	'OnRecordTimeChanged',
+	'OnRecordStopped',
+	'OnRecordFinalized',
+	'OnLiveExcerptStarted',
+	'OnLiveExcerptFinished',
+	'OnProfilesChanged',
+	'OnStreamingStarted',
+	'OnStreamingStopped',
+	'OnStreamingProfileUpdated',
+	'OnRecordingAdded',
+	'OnRecordingDeleted',
+	'OnRecordingUpdated',
+	'OnPublishingJobAdded',
+	'OnPublishingJobDeleted',
+	'OnPublishingJobUpdated',
+	'OnUserSelectedMicrophoneChanged',
+	'OnLivePresetChanged',
+	'OnMicrophoneStateChanged',
+	'OnPresetsBankChanged',
+	'OnAutomationAssistMessageNotified',
+	'OnAutoTitlingConfigUpdated',
+	'OnAutomationNotification',
+	'OnLiveTitlerFileChanged',
+	'OnTitlerElementUpdated',
+	'OnTitlerStaticFileLiveRowChanged',
+	'OnTitlerStaticFileRowDeleted',
+	'OnTitlerStaticFileRowAdded',
+	'OnTitlerStaticFileRowEdited',
+	'OnTitlerSocialMediaMessageReceived',
+	'OnLiveComposerFileChanged',
+	'OnLiveComposerCompoChanged',
+	'OnLiveComposerFileIdChanged',
+	'OnLiveComposerCompoIdChanged',
+	'OnLiveScenesFileChanged',
+	'OnLiveScenesSceneChanged',
+	'OnSceneSnapshotUpdated',
+	'OnPlaylistPlay',
+	'OnPlaylistStop',
+	'OnLivePlaylistItemChanged',
+	'OnLivePlaylistFileChanged',
+	'OnLivePlaylistItemAdded',
+	'OnLivePlaylistItemRemoved',
+	'OnLivePlaylistItemIndexChanged',
+	'OnLivePlaylistItemModified',
+	'OnPlaylistItemModified',
+	'OnPlaylistLoadingStateChanged',
+	'OnLiveSourceChanged',
+	'OnLiveSourceChanging',
+	'OnPilotedDeviceChanged',
+	'OnAssistViewedSceneChanged',
+	'OnZoneAdded',
+	'OnZoneDeleted',
+	'OnZoneUpdated',
+] as const
+
+type SignalRStateMethod = (typeof SIGNALR_STATE_METHODS)[number]
+type ReceiverMethod = (typeof SIGNALR_RECEIVER_METHODS)[number]
+type RecordLike = Record<string, any>
+type ReceiverConnection = Pick<signalR.HubConnection, 'on'>
+
+const refreshTimers = new WeakMap<MulticamInstance, NodeJS.Timeout>()
+const pendingRefreshes = new WeakMap<
+	MulticamInstance,
+	{ targets: Set<PollScope | 'all'>; forceSignalRRefresh: boolean }
+>()
+
+function isRecord(value: unknown): value is RecordLike {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getField(value: unknown, ...keys: string[]): any {
+	if (!isRecord(value)) return undefined
+	for (const key of keys) {
+		if (Object.prototype.hasOwnProperty.call(value, key)) return value[key]
+	}
+	return undefined
+}
+
+function safeStringify(value: unknown): string {
 	try {
-		return JSON.stringify(value)
-	} catch (_e) {
-		return String(value)
+		return JSON.stringify(value) ?? ''
+	} catch (_error) {
+		return '[Unserializable value]'
 	}
 }
 
-export function InitSignalR(instance: MulticamInstance): void {
-	void (async () => {
-		instance.log('debug', 'Initializing SignalR connection')
+function valueToString(value: unknown): string {
+	if (value === null || value === undefined) return ''
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return `${value}`
+	return safeStringify(value)
+}
 
-		const url = `http://${instance.config.host}:${instance.config.port}/signalr`
+function stringId(value: unknown): string {
+	const id = getField(value, 'id', 'Id')
+	return id === undefined || id === null ? '' : String(id)
+}
 
-		const connection = new signalR.HubConnectionBuilder()
-			.withUrl(url)
-			.withAutomaticReconnect()
-			.configureLogging(signalR.LogLevel.Information)
-			.build()
+function displayName(value: unknown): string {
+	const name = getField(
+		value,
+		'name',
+		'Name',
+		'mediaName',
+		'MediaName',
+		'title',
+		'Title',
+		'fileName',
+		'FileName',
+		'composerFileName',
+		'ComposerFileName',
+		'composerSceneName',
+		'ComposerSceneName',
+	)
+	return name === undefined || name === null ? stringId(value) : String(name)
+}
 
-		connection.onclose((err) => {
-			instance.log('warn', `SignalR closed: ${err?.message ?? 'no error'}`)
-		})
-		connection.onreconnecting((err) => {
-			instance.log('warn', `SignalR reconnecting: ${err?.message ?? 'no error'}`)
-		})
-		connection.onreconnected((connectionId) => {
-			instance.log('info', `SignalR reconnected. connectionId=${connectionId ?? 'null'}`)
-		})
+function choicesOrNone(choices: DropdownChoice[]): DropdownChoice[] {
+	return choices.length > 0 ? choices : [{ id: 'none', label: 'None' }]
+}
 
-		// --- IAssistHubToClient (server -> client) ---
+function choicesChanged(current: DropdownChoice[], next: DropdownChoice[]): boolean {
+	return JSON.stringify(current) !== JSON.stringify(next)
+}
 
-		connection.on('OnApplicationExited', () => {
-			instance.log('info', 'SignalR: Application Exited')
-			instance.setVariableValues({ runningApp: 'None' })
-		})
+function markSignalREvent(instance: MulticamInstance, eventName: string, args: unknown[]): void {
+	const payload = safeStringify(args)
+	instance.SIGNALR_LAST_EVENT = eventName
+	instance.SIGNALR_LAST_PAYLOAD = payload
+	instance.setVariableValues({
+		signalrLastEvent: eventName,
+		signalrLastPayload: payload,
+	})
+	instance.log('debug', `SignalR: ${eventName}: ${payload}`)
+}
 
-		connection.on('OnApplicationInitialized', () => {
-			instance.log('info', 'SignalR: Application Initialized')
-		})
+function setConnectionState(instance: MulticamInstance, connected: boolean): void {
+	instance.SIGNALR_CONNECTED = connected
+	instance.setVariableValues({ signalrConnected: connected })
+	instance.checkFeedbacks('signalrConnected')
+}
 
-		connection.on('OnApplicationInitializedWithDetails', (moduleName: string, room: any) => {
-			instance.log('info', `SignalR: Initialized (${moduleName})`)
-			instance.log('debug', `Data: ${safeStringify(room)}`)
-			instance.setVariableValues({ runningApp: moduleName })
-		})
-
-		connection.on('OnAssistViewedSceneChanged', (sceneInfo: any) => {
-			instance.log('info', `SignalR: Assist Viewed Scene Changed: ${sceneInfo?.name ?? 'null'}`)
-		})
-
-		connection.on('OnAutoTitlingConfigUpdated', (updatedInfo: any) => {
-			instance.log('debug', `SignalR: OnAutoTitlingConfigUpdated: ${safeStringify([updatedInfo])}`)
-		})
-
-		connection.on('OnAutomaticModeChanged', (isAuto: boolean) => {
-			instance.log('info', `SignalR: Automatic Mode Changed: ${isAuto}`)
-			instance.setVariableValues({
-				applicationAutoState: isAuto ? 'Auto' : 'Manual',
-			})
-		})
-
-		connection.on('OnAutomationAssistMessageNotified', (message: string) => {
-			instance.log('debug', `SignalR: OnAutomationAssistMessageNotified: ${safeStringify([message])}`)
-		})
-
-		connection.on('OnAutomationNotification', (notification: any) => {
-			instance.log('debug', `SignalR: OnAutomationNotification: ${safeStringify([notification])}`)
-		})
-
-		connection.on('OnLiveComposerCompoChanged', (compoName: string) => {
-			instance.log('info', `SignalR: Composer Composition Changed: ${compoName}`)
-			instance.setVariableValues({
-				composerSelectedCompositionSceneName: compoName ?? 'None',
-			})
-		})
-
-		connection.on('OnLiveComposerCompoIdChanged', (compoId: string) => {
-			instance.log('info', `SignalR: Composer Composition ID Changed: ${compoId}`)
-			instance.setVariableValues({
-				composerSelectedCompositionSceneId: compoId ?? 'None',
-			})
-		})
-
-		connection.on('OnLiveComposerFileChanged', (fileName: string | null) => {
-			instance.log('info', `SignalR: Live Composer File Changed: ${fileName ?? 'null'}`)
-			instance.setVariableValues({ composerSelectedFileName: fileName ?? 'None' })
-		})
-
-		connection.on('OnLiveComposerFileIdChanged', (composerFileId: string | null) => {
-			instance.log('info', `SignalR: Live Composer File ID Changed: ${composerFileId ?? 'null'}`)
-			instance.setVariableValues({ composerSelectedFileId: composerFileId ?? 'None' })
-		})
-
-		connection.on('OnLiveExcerptFinished', () => {
-			instance.log('debug', 'SignalR: OnLiveExcerptFinished')
-		})
-
-		connection.on('OnLiveExcerptStarted', () => {
-			instance.log('debug', 'SignalR: OnLiveExcerptStarted')
-		})
-
-		connection.on('OnLivePlaylistFileChanged', (medialist: any) => {
-			instance.log('info', `SignalR: Live Playlist File Changed: ${medialist?.name ?? 'unknown'}`)
-			instance.log('debug', `Playlist: ${safeStringify(medialist)}`)
-		})
-
-		connection.on('OnLivePlaylistItemAdded', (item: any) => {
-			instance.log('debug', `SignalR: OnLivePlaylistItemAdded: ${safeStringify([item])}`)
-		})
-
-		connection.on('OnLivePlaylistItemChanged', (item: any) => {
-			instance.log('debug', `SignalR: OnLivePlaylistItemChanged: ${safeStringify([item])}`)
-		})
-
-		connection.on('OnLivePlaylistItemIndexChanged', (itemId: string, newIndex: number) => {
-			instance.log('debug', `SignalR: OnLivePlaylistItemIndexChanged: ${safeStringify([itemId, newIndex])}`)
-		})
-
-		connection.on('OnLivePlaylistItemModified', (item: any) => {
-			instance.log('debug', `SignalR: OnLivePlaylistItemModified: ${safeStringify([item])}`)
-		})
-
-		connection.on('OnLivePlaylistItemRemoved', (itemId: string) => {
-			instance.log('debug', `SignalR: OnLivePlaylistItemRemoved: ${safeStringify([itemId])}`)
-		})
-
-		connection.on('OnLiveScenesFileChanged', (sceneInfo: any | null) => {
-			instance.log('info', `SignalR: Live Scenes File Changed: ${sceneInfo?.name ?? 'null'}`)
-
-			instance.setVariableValues({
-				sceneSelectedFileName: sceneInfo?.name ?? 'None',
-				sceneSelectedFileId: sceneInfo?.id ?? 'None',
-			})
-		})
-
-		connection.on('OnLiveTitlerFileChanged', (data: any | null) => {
-			instance.log('info', `SignalR: Live Titler File Changed: ${data?.name ?? 'null'}`)
-			instance.setVariableValues({
-				titlerSelectedFileName: data?.name ?? 'None',
-				titlerSelectedFileId: data?.id ?? 'None',
-			})
-		})
-
-		connection.on('OnMultipleDisplaySetupChanged', (setup: any) => {
-			instance.log('debug', `SignalR: OnMultipleDisplaySetupChanged: ${safeStringify([setup])}`)
-		})
-
-		connection.on('OnPreviewCompoChanged', (compoName: string) => {
-			instance.log('debug', `SignalR: OnPreviewCompoChanged: ${safeStringify([compoName])}`)
-		})
-
-		connection.on('OnPreviewCompoIdChanged', (compoId: string) => {
-			instance.log('debug', `SignalR: OnPreviewCompoIdChanged: ${safeStringify([compoId])}`)
-		})
-
-		connection.on('OnPreviewComposerFileChanged', (fileName: string) => {
-			instance.log('debug', `SignalR: OnPreviewComposerFileChanged: ${safeStringify([fileName])}`)
-		})
-
-		connection.on('OnPreviewComposerFileIdChanged', (composerFileId: string) => {
-			instance.log('debug', `SignalR: OnPreviewComposerFileIdChanged: ${safeStringify([composerFileId])}`)
-		})
-
-		connection.on('OnPreviewSceneChanged', (sceneInfo: any) => {
-			instance.log('debug', `SignalR: OnPreviewSceneChanged: ${safeStringify([sceneInfo])}`)
-		})
-
-		connection.on('OnRoomAdded', (room: any) => {
-			instance.log('debug', `SignalR: OnRoomAdded: ${safeStringify([room])}`)
-		})
-
-		connection.on('OnRoomDeleted', (roomId: string) => {
-			instance.log('debug', `SignalR: OnRoomDeleted: ${safeStringify([roomId])}`)
-		})
-
-		connection.on('OnRoomUpdated', (room: any) => {
-			instance.log('debug', `SignalR: OnRoomUpdated: ${safeStringify([room])}`)
-		})
-
-		connection.on('OnSelectedZoneChanged', (zoneId: string) => {
-			instance.log('debug', `SignalR: OnSelectedZoneChanged: ${safeStringify([zoneId])}`)
-		})
-
-		connection.on('OnStaticTitleChanged', (title: any) => {
-			instance.log('debug', `SignalR: OnStaticTitleChanged: ${safeStringify([title])}`)
-		})
-
-		connection.on('OnTitlerElementAdded', (element: any) => {
-			instance.log('debug', `SignalR: OnTitlerElementAdded: ${safeStringify([element])}`)
-		})
-
-		connection.on('OnTitlerElementDeleted', (elementId: string) => {
-			instance.log('debug', `SignalR: OnTitlerElementDeleted: ${safeStringify([elementId])}`)
-		})
-
-		connection.on('OnTitlerElementUpdated', (data: any) => {
-			instance.log('info', 'SignalR: Titler Element Updated')
-			instance.log('debug', `Data: ${safeStringify(data)}`)
-		})
-
-		connection.on('OnTitlerElementsCleared', () => {
-			instance.log('debug', 'SignalR: OnTitlerElementsCleared')
-		})
-
-		connection.on('OnTitlerFileSelectedRowEdited', (rowIndex: number, row: any) => {
-			instance.log('debug', `SignalR: OnTitlerFileSelectedRowEdited: ${safeStringify([rowIndex, row])}`)
-		})
-
-		connection.on('OnTitlerFileSelectedRowSelectionChanged', (rowIndex: number) => {
-			instance.log('debug', `SignalR: OnTitlerFileSelectedRowSelectionChanged: ${safeStringify([rowIndex])}`)
-		})
-
-		connection.on('OnTitlerSelectedFileRowsCleared', () => {
-			instance.log('debug', 'SignalR: OnTitlerSelectedFileRowsCleared')
-		})
-
-		connection.on('OnTitlerSelectedFileRowsUpdated', (rows: any[]) => {
-			instance.log('debug', `SignalR: OnTitlerSelectedFileRowsUpdated: ${safeStringify([rows])}`)
-		})
-
-		connection.on('OnTitlerStaticFileRowEdited', (rowIndex: number, row: any) => {
-			instance.log('debug', `SignalR: OnTitlerStaticFileRowEdited: ${safeStringify([rowIndex, row])}`)
-		})
-
-		connection.on('OnUserSelectedMicrophoneChanged', (microphoneId: string) => {
-			instance.log('debug', `SignalR: OnUserSelectedMicrophoneChanged: ${safeStringify([microphoneId])}`)
-		})
-
-		connection.on('OnZoneAdded', (zone: any) => {
-			instance.log('debug', `SignalR: OnZoneAdded: ${safeStringify([zone])}`)
-		})
-
-		connection.on('OnZoneDeleted', (zoneId: string) => {
-			instance.log('debug', `SignalR: OnZoneDeleted: ${safeStringify([zoneId])}`)
-		})
-
-		connection.on('OnZoneUpdated', (zone: any) => {
-			instance.log('debug', `SignalR: OnZoneUpdated: ${safeStringify([zone])}`)
-		})
-
-		connection.on('OnRecordStarted', (media: any) => {
-			instance.log('debug', `SignalR: OnRecordStarted: ${safeStringify([media])}`)
-			instance.setVariableValues({
-				recording: true,
-			})
-			instance.checkFeedbacks('recording')
-		})
-
-		connection.on('OnRecordStopped', () => {
-			instance.log('debug', 'SignalR: OnRecordStopped')
-			instance.setVariableValues({
-				recording: false,
-			})
-			instance.checkFeedbacks('recording')
-		})
-
-		connection.on('OnStreamingStarted', (profile: StreamingProfile) => {
-			instance.log('debug', `SignalR: OnStreamingStarted: ${safeStringify([profile])}`)
-			instance.ACTIVE_STREAMS.push(profile)
-			instance.checkFeedbacks('streaming')
-		})
-		connection.on('OnStreamingStopped', (profile: StreamingProfile) => {
-			instance.log('debug', `SignalR: OnStreamingStopped: ${safeStringify([profile])}`)
-			instance.ACTIVE_STREAMS = instance.ACTIVE_STREAMS.filter((p) => p.id !== profile.id)
-			instance.checkFeedbacks('streaming')
-		})
-
-		// ---- start ----
-		try {
-			await connection.start()
-			instance.log('info', 'SignalR connected')
-		} catch (e: any) {
-			instance.log('error', `SignalR failed to start: ${e?.message ?? e}`)
+function queueDataRefresh(
+	instance: MulticamInstance,
+	targets: PollScope | 'all' | Array<PollScope | 'all'>,
+	forceSignalRRefresh: boolean = false,
+): void {
+	let pending = pendingRefreshes.get(instance)
+	if (!pending) {
+		pending = { targets: new Set(), forceSignalRRefresh: false }
+		pendingRefreshes.set(instance, pending)
+	}
+	for (const target of Array.isArray(targets) ? targets : [targets]) pending.targets.add(target)
+	pending.forceSignalRRefresh ||= forceSignalRRefresh
+	if (refreshTimers.has(instance)) return
+	const timer = setTimeout(() => {
+		refreshTimers.delete(instance)
+		const request = pendingRefreshes.get(instance)
+		pendingRefreshes.delete(instance)
+		if (!request) return
+		const options = { forceSignalRRefresh: request.forceSignalRRefresh }
+		if (request.targets.has('all')) {
+			void runPollCycle(instance, options)
+			const scopedTargets = new Set([...request.targets].filter((target): target is PollScope => target !== 'all'))
+			if (scopedTargets.size > 0) void runPollScopes(instance, scopedTargets, options)
+		} else {
+			void runPollScopes(instance, request.targets as Set<PollScope>, options)
 		}
+	}, 250)
+	refreshTimers.set(instance, timer)
+}
 
-		instance._signalR = connection
-	})()
+function upsertById(items: any[], item: unknown): any[] {
+	const id = stringId(item)
+	if (!id) return items
+	const index = items.findIndex((candidate) => stringId(candidate) === id)
+	if (index < 0) return [...items, item]
+	const result = [...items]
+	result[index] = item
+	return result
+}
+
+function removeById(items: any[], itemOrId: unknown): any[] {
+	const id = isRecord(itemOrId) ? stringId(itemOrId) : valueToString(itemOrId)
+	return id ? items.filter((candidate) => stringId(candidate) !== id) : items
+}
+
+function setPublisherRecordings(instance: MulticamInstance, recordings: unknown): void {
+	if (!Array.isArray(recordings)) return
+	instance.PUBLISHER_RECORDINGS = recordings
+	instance.setVariableValues({ publisherRecordingCount: recordings.length })
+	const choices = choicesOrNone(
+		recordings
+			.filter((recording) => stringId(recording))
+			.map((recording) => ({ id: stringId(recording), label: displayName(recording) })),
+	)
+	if (choicesChanged(instance.CHOICES_PUBLISHER_RECORDINGS, choices)) {
+		instance.CHOICES_PUBLISHER_RECORDINGS = choices
+		instance.updateActions()
+	}
+}
+
+function setPublisherWorkflows(instance: MulticamInstance, workflows: unknown): void {
+	if (!Array.isArray(workflows)) return
+	instance.PUBLISHER_WORKFLOWS = workflows
+	const choices = choicesOrNone(
+		workflows
+			.filter((workflow) => Boolean(getField(workflow, 'isFullyAutomated', 'IsFullyAutomated')))
+			.map((workflow) => {
+				const name = displayName(workflow)
+				return { id: name, label: name }
+			})
+			.filter((choice) => choice.id),
+	)
+	if (choicesChanged(instance.CHOICES_PUBLISHER_WORKFLOWS, choices)) {
+		instance.CHOICES_PUBLISHER_WORKFLOWS = choices
+		instance.updateActions()
+	}
+}
+
+function setPublishingJobs(instance: MulticamInstance, jobs: unknown): void {
+	if (!Array.isArray(jobs)) return
+	instance.SIGNALR_PUBLISHING_JOBS = jobs
+	instance.setVariableValues({ signalrPublishingJobs: safeStringify(jobs) })
+}
+
+function setCropZones(instance: MulticamInstance, zones: unknown): void {
+	if (!Array.isArray(zones)) return
+	instance.SIGNALR_CROP_ZONES = zones
+	instance.setVariableValues({ signalrCropZones: safeStringify(zones) })
+	const choices = choicesOrNone(
+		zones
+			.filter((zone) => stringId(zone))
+			.map((zone) => ({ id: stringId(zone), label: displayName(zone) || stringId(zone) })),
+	)
+	if (choicesChanged(instance.CHOICES_SIGNALR_CROP_ZONES, choices)) {
+		instance.CHOICES_SIGNALR_CROP_ZONES = choices
+		instance.updateActions()
+	}
+}
+
+function normalizeStreamingProfile(profile: unknown, started?: boolean): StreamingProfile | null {
+	if (!isRecord(profile)) return null
+	const id = String(getField(profile, 'id', 'Id') ?? '')
+	if (!id) return null
+	return {
+		id,
+		name: String(getField(profile, 'name', 'Name') ?? id),
+		isEnabled: Boolean(getField(profile, 'isEnabled', 'IsEnabled')),
+		broadcastServerHostname: String(getField(profile, 'broadcastServerHostname', 'BroadcastServerHostname') ?? ''),
+		broadcastStreamID: String(getField(profile, 'broadcastStreamID', 'BroadcastStreamID') ?? ''),
+		isStarted: started ?? Boolean(getField(profile, 'isStarted', 'IsStarted')),
+		canBeLaunchedRemotely: Boolean(getField(profile, 'canBeLaunchedRemotely', 'CanBeLaunchedRemotely')),
+		errorMessage: String(getField(profile, 'errorMessage', 'ErrorMessage') ?? ''),
+	}
+}
+
+function updateActiveStream(instance: MulticamInstance, profile: unknown, started?: boolean): void {
+	const normalized = normalizeStreamingProfile(profile, started)
+	if (!normalized) return
+	const existing = instance.STREAMING_PROFILES.find((candidate) => stringId(candidate) === normalized.id)
+	const cachedProfile = {
+		...(isRecord(existing) ? existing : {}),
+		...(isRecord(profile) ? profile : {}),
+		Id: normalized.id,
+		Name: normalized.name,
+		IsStarted: normalized.isStarted,
+	}
+	instance.STREAMING_PROFILES = upsertById(instance.STREAMING_PROFILES, cachedProfile)
+	const choices = choicesOrNone(
+		instance.STREAMING_PROFILES.map((candidate) => ({ id: stringId(candidate), label: displayName(candidate) })),
+	)
+	if (choicesChanged(instance.CHOICES_STREAMING_PROFILES, choices)) {
+		instance.CHOICES_STREAMING_PROFILES = choices
+		instance.updateActions()
+		instance.updateFeedbacks()
+	}
+	instance.ACTIVE_STREAMS = normalized.isStarted
+		? upsertById(instance.ACTIVE_STREAMS, normalized)
+		: removeById(instance.ACTIVE_STREAMS, normalized.id)
+	instance.setVariableValues({
+		streamingActiveProfiles: instance.ACTIVE_STREAMS.map((item) => item.name).join(', '),
+		streamingActiveProfileCount: instance.ACTIVE_STREAMS.length,
+		streamingAnyActive: instance.ACTIVE_STREAMS.length > 0,
+	})
+	instance.checkFeedbacks('streaming')
+}
+
+function updateLiveExtract(instance: MulticamInstance, info: unknown, inProgress?: boolean): void {
+	const current = isRecord(info) ? info : {}
+	const active = inProgress ?? Boolean(getField(current, 'isInProgress', 'IsInProgress'))
+	const seconds = active ? Number(getField(current, 'secondsToAutomaticEnd', 'SecondsToAutomaticEnd') ?? 0) : 0
+	instance.RECORDING_LIVE_EXTRACT = { ...current, IsInProgress: active, SecondsToAutomaticEnd: seconds }
+	instance.setVariableValues({
+		recordingLiveExtract: active,
+		recordingLiveExtractSecondsRemaining: Number.isFinite(seconds) ? seconds : 0,
+	})
+}
+
+function setApplicationSpecificVariable(
+	instance: MulticamInstance,
+	confVariable: string,
+	radioVariable: string,
+	value: any,
+): void {
+	const running = instance.RUNNING_APPLICATION.toLowerCase()
+	if (running.includes('radio')) instance.setVariableValues({ [radioVariable]: value })
+	else if (running.includes('conf')) instance.setVariableValues({ [confVariable]: value })
+	else instance.setVariableValues({ [confVariable]: value, [radioVariable]: value })
+}
+
+function normalizeTitlerElement(element: unknown): unknown {
+	if (!isRecord(element)) return element
+	const normalized = { ...element }
+	const id = getField(element, 'id', 'Id')
+	const name = getField(element, 'name', 'Name')
+	const elementType = getField(element, 'elementType', 'ElementType')
+	const isVisible = getField(element, 'isVisible', 'IsVisible')
+	if (id !== undefined) normalized.Id = id
+	if (name !== undefined) normalized.Name = name
+	if (elementType !== undefined) normalized.ElementType = elementType
+	if (isVisible !== undefined) normalized.IsVisible = isVisible
+	return normalized
+}
+
+function setTitlerLiveRow(instance: MulticamInstance, elementId: unknown, row: unknown): void {
+	const element = instance.TITLER_SELECTED_FILE_ELEMENTS.find((item) => stringId(item) === valueToString(elementId))
+	if (!element) return
+	const rowId = stringId(row)
+	const kind = String(getField(element, 'ElementType', 'elementType') ?? '').toLowerCase()
+	if (kind === 'speaker') element.LiveSpeakerRowId = rowId
+	else if (kind === 'panel') element.LivePanelRowId = rowId
+	instance.checkFeedbacks('titlerElementSpeakerRowLive', 'titlerElementPanelRowLive')
+}
+
+function setMedialistState(instance: MulticamInstance, medialistId: unknown, item?: unknown, position?: unknown): void {
+	const id = valueToString(medialistId)
+	if (id) {
+		instance.setVariableValues({ medialistSelectedId: id })
+		if (stringId(instance.MEDIALIST_SELECTED) !== id) instance.MEDIALIST_SELECTED = { Id: id, id }
+	}
+	if (item !== undefined) {
+		instance.MEDIALIST_SELECTED_MEDIA = item as any
+		instance.setVariableValues({
+			medialistSelectedMedia: safeStringify(item),
+			medialistSelectedMediaName: displayName(item),
+			medialistSelectedMediaId: stringId(item),
+		})
+	}
+	if (position !== undefined) instance.setVariableValues({ medialistPosition: Number(position) || 0 })
+}
+
+function setSelectedMedialist(instance: MulticamInstance, medialist: unknown): void {
+	const id = stringId(medialist)
+	instance.MEDIALIST_SELECTED = isRecord(medialist) ? { ...medialist, Id: id } : id ? { Id: id, id } : {}
+	if (isRecord(medialist)) instance.MEDIALISTS = upsertById(instance.MEDIALISTS, medialist)
+	const items = getField(medialist, 'items', 'Items')
+	const choices = choicesOrNone(
+		(Array.isArray(items) ? items : [])
+			.filter((item) => stringId(item))
+			.map((item) => ({
+				id: stringId(item),
+				label: `${displayName(medialist)} - ${displayName(item)}`,
+			})),
+	)
+	if (choicesChanged(instance.CHOICES_MEDIALIST_SELECTED_MEDIA, choices)) {
+		instance.CHOICES_MEDIALIST_SELECTED_MEDIA = choices
+		instance.updateActions()
+		instance.updateFeedbacks()
+	}
+	instance.setVariableValues({
+		medialistSelectedId: id || 'None',
+		medialistSelectedName: displayName(medialist) || 'None',
+	})
+	instance.checkFeedbacks('medialistSelected')
+}
+
+export function registerSignalREvents(instance: MulticamInstance, connection: ReceiverConnection): void {
+	const registered = new Set<string>()
+	const on = (name: ReceiverMethod | string, handler: (...args: any[]) => void | Promise<void>): void => {
+		registered.add(name)
+		connection.on(name, async (...args: any[]) => {
+			markSignalREvent(instance, name, args)
+			try {
+				await handler(...args)
+			} catch (error: any) {
+				instance.log('warn', `SignalR handler ${name} failed: ${error?.message ?? error}`)
+			}
+		})
+	}
+
+	on('OnApplicationInitialized', () => queueDataRefresh(instance, 'all', true))
+	on('OnApplicationInitializedWithDetails', (moduleName: string, room: unknown) => {
+		instance.RUNNING_APPLICATION = moduleName ?? ''
+		if (isRecord(room)) instance.ROOM_SELECTED = room
+		instance.setVariableValues({
+			runningApp: moduleName || 'None',
+			selected_room: getField(room, 'name', 'Name') ?? '',
+			selectedRoomId: getField(room, 'id', 'Id') ?? '',
+		})
+		queueDataRefresh(instance, 'all', true)
+	})
+	on('OnApplicationExited', () => {
+		instance.RUNNING_APPLICATION = ''
+		instance.RECORDING = false
+		instance.ACTIVE_STREAMS = []
+		instance.setVariableValues({
+			runningApp: 'None',
+			recording: false,
+			recordingState: 'Stopped',
+			streamingActiveProfiles: '',
+			streamingActiveProfileCount: 0,
+			streamingAnyActive: false,
+		})
+		instance.checkAllFeedbacks()
+		queueDataRefresh(instance, 'application')
+	})
+	on('OnAutomaticModeChanged', (isAuto: boolean) => {
+		instance.setVariableValues({ applicationAutoState: isAuto ? 'Auto' : 'Manual' })
+		instance.checkFeedbacks('applicationAutoMode')
+	})
+	on('OnRecordingStarting', () => {
+		instance.setVariableValues({ recordingState: 'Starting' })
+	})
+	on('OnRecordStarted', () => {
+		instance.RECORDING = true
+		instance.setVariableValues({ recording: true, recordingState: 'Recording' })
+		instance.checkFeedbacks('recording')
+	})
+	on('OnRecordTimeChanged', (currentTime: unknown) => {
+		instance.setVariableValues({ signalrRecordTime: valueToString(currentTime) })
+	})
+	on('OnRecordStopped', () => {
+		instance.RECORDING = false
+		instance.setVariableValues({ recording: false, recordingState: 'Stopped' })
+		instance.checkFeedbacks('recording')
+	})
+	on('OnRecordFinalized', () => {
+		instance.setVariableValues({ recordingState: 'Finalized' })
+		queueDataRefresh(instance, 'publisher', true)
+	})
+	on('OnLiveExcerptStarted', () => {
+		updateLiveExtract(instance, instance.RECORDING_LIVE_EXTRACT, true)
+		queueDataRefresh(instance, 'recording')
+	})
+	on('OnLiveExcerptFinished', () => updateLiveExtract(instance, instance.RECORDING_LIVE_EXTRACT, false))
+	on('OnProfilesChanged', () => queueDataRefresh(instance, 'streaming'))
+	on('OnStreamingStarted', (profile: unknown) => updateActiveStream(instance, profile, true))
+	on('OnStreamingStopped', (profile: unknown) => updateActiveStream(instance, profile, false))
+	on('OnStreamingProfileUpdated', (profile: unknown) => {
+		updateActiveStream(instance, profile)
+	})
+	on('OnRecordingAdded', (recording: unknown) => {
+		setPublisherRecordings(instance, upsertById(instance.PUBLISHER_RECORDINGS, recording))
+	})
+	on('OnRecordingDeleted', (recording: unknown) => {
+		setPublisherRecordings(instance, removeById(instance.PUBLISHER_RECORDINGS, recording))
+	})
+	on('OnRecordingUpdated', (recording: unknown) => {
+		setPublisherRecordings(instance, upsertById(instance.PUBLISHER_RECORDINGS, recording))
+	})
+	on('OnPublishingJobAdded', (job: unknown) => {
+		setPublishingJobs(instance, upsertById(instance.SIGNALR_PUBLISHING_JOBS, job))
+	})
+	on('OnPublishingJobDeleted', (job: unknown) => {
+		setPublishingJobs(instance, removeById(instance.SIGNALR_PUBLISHING_JOBS, job))
+	})
+	on('OnPublishingJobUpdated', (job: unknown) => {
+		setPublishingJobs(instance, upsertById(instance.SIGNALR_PUBLISHING_JOBS, job))
+	})
+	on('OnUserSelectedMicrophoneChanged', (micNumber: number) => {
+		instance.SIGNALR_SELECTED_MICROPHONE = Number(micNumber)
+		instance.setVariableValues({ signalrSelectedMicrophone: Number(micNumber) })
+	})
+	on('OnLivePresetChanged', () => queueDataRefresh(instance, 'automation'))
+	on('OnMicrophoneStateChanged', (micState: unknown) => {
+		instance.setVariableValues({ signalrMicrophoneState: safeStringify(micState) })
+		const mode = getField(micState, 'automationMode', 'AutomationMode')
+		if (mode !== undefined) setApplicationSpecificVariable(instance, 'confAutomationMode', 'radioAutomationMode', mode)
+		const running = instance.RUNNING_APPLICATION.toLowerCase()
+		if (running.includes('radio')) instance.RADIO_STATE.microphones = micState
+		else if (running.includes('conf')) instance.CONF_STATE.microphones = micState
+		queueDataRefresh(instance, 'automation')
+	})
+	on('OnPresetsBankChanged', (bankName: string) => {
+		setApplicationSpecificVariable(instance, 'confPresetBank', 'radioPresetBank', bankName ?? '')
+		queueDataRefresh(instance, 'automation')
+	})
+	on('OnAutomationAssistMessageNotified', (message: string) => {
+		instance.setVariableValues({ signalrAutomationAssistMessage: message ?? '' })
+	})
+	on('OnAutoTitlingConfigUpdated', (updatedInfo: unknown) => {
+		instance.setVariableValues({ signalrAutoTitlingConfig: safeStringify(updatedInfo) })
+		const enabled = getField(updatedInfo, 'isEnabled', 'IsEnabled', 'enabled', 'Enabled')
+		if (typeof enabled === 'boolean') {
+			setApplicationSpecificVariable(instance, 'confAutoTitling', 'radioAutoTitling', enabled)
+			const running = instance.RUNNING_APPLICATION.toLowerCase()
+			if (running.includes('radio')) instance.RADIO_STATE.autoTitling = updatedInfo
+			else if (running.includes('conf')) instance.CONF_STATE.autoTitling = updatedInfo
+		}
+	})
+	on('OnAutomationNotification', (notification: unknown) => {
+		instance.setVariableValues({ signalrAutomationNotification: safeStringify(notification) })
+	})
+	on('OnLiveTitlerFileChanged', (apiFile: unknown) => {
+		instance.TITLER_FILE_SELECTED = isRecord(apiFile) ? apiFile : {}
+		instance.setVariableValues({
+			titlerSelectedFileName: displayName(apiFile) || 'None',
+			titlerSelectedFileId: stringId(apiFile) || 'None',
+		})
+		queueDataRefresh(instance, 'titler')
+	})
+	on('OnTitlerElementUpdated', (updatedElement: unknown) => {
+		const normalized = normalizeTitlerElement(updatedElement)
+		const id = stringId(normalized)
+		const existing = instance.TITLER_SELECTED_FILE_ELEMENTS.find((element) => stringId(element) === id)
+		const merged = isRecord(existing) && isRecord(normalized) ? { ...existing, ...normalized } : normalized
+		instance.TITLER_SELECTED_FILE_ELEMENTS = upsertById(instance.TITLER_SELECTED_FILE_ELEMENTS, merged)
+		instance.checkFeedbacks('titlerElementVisible')
+		queueDataRefresh(instance, 'titler')
+	})
+	on('OnTitlerStaticFileLiveRowChanged', (elementId: unknown, newLiveRow: unknown) => {
+		setTitlerLiveRow(instance, elementId, newLiveRow)
+	})
+	on('OnTitlerStaticFileRowDeleted', () => queueDataRefresh(instance, 'titler'))
+	on('OnTitlerStaticFileRowAdded', () => queueDataRefresh(instance, 'titler'))
+	on('OnTitlerStaticFileRowEdited', () => queueDataRefresh(instance, 'titler'))
+	on('OnTitlerSocialMediaMessageReceived', (post: unknown) => {
+		instance.setVariableValues({ signalrSocialMediaPost: safeStringify(post) })
+	})
+	on('OnLiveComposerFileChanged', (fileName: string | null) => {
+		instance.setVariableValues({ composerSelectedFileName: fileName ?? 'None' })
+	})
+	on('OnLiveComposerCompoChanged', (compoName: string | null) => {
+		instance.setVariableValues({ composerSelectedCompositionSceneName: compoName ?? 'None' })
+	})
+	on('OnLiveComposerFileIdChanged', (composerFileId: unknown) => {
+		const id = valueToString(composerFileId)
+		instance.COMPOSER_FILE_SELECTED = id
+		const selected = instance.COMPOSER_FILES.find(
+			(file) => String(getField(file, 'composerFileId', 'ComposerFileId', 'id', 'Id') ?? '') === id,
+		)
+		instance.setVariableValues({
+			composerSelectedFileId: id || 'None',
+			...(selected ? { composerSelectedFileName: displayName(selected) || 'None' } : {}),
+		})
+		instance.checkFeedbacks('composerSelectedFile')
+		queueDataRefresh(instance, 'composer')
+	})
+	on('OnLiveComposerCompoIdChanged', (compoId: unknown) => {
+		const id = valueToString(compoId)
+		instance.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION_ID = id
+		const compositions = Array.isArray(instance.COMPOSER_FILE_SELECTED_COMPOSITIONS)
+			? instance.COMPOSER_FILE_SELECTED_COMPOSITIONS
+			: []
+		const selected = compositions.find(
+			(composition: unknown) =>
+				String(getField(composition, 'composerSceneId', 'ComposerSceneId', 'id', 'Id') ?? '') === id,
+		)
+		if (selected) instance.COMPOSER_FILE_SELECTED_COMPOSITIONS_SELECTED_COMPOSITION = selected
+		instance.setVariableValues({
+			composerSelectedCompositionSceneId: id || 'None',
+			...(selected ? { composerSelectedCompositionSceneName: displayName(selected) || 'None' } : {}),
+		})
+		instance.checkFeedbacks('composerSelectedComposition')
+	})
+	on('OnLiveScenesFileChanged', (scenesFileId: unknown) => {
+		const id = valueToString(scenesFileId)
+		const selected = instance.SCENE_FILES.find((file) => stringId(file) === id)
+		instance.SCENES_FILE_SELECTED = selected ?? (id ? { Id: id } : {})
+		instance.setVariableValues({
+			sceneSelectedFileId: id || 'None',
+			...(selected ? { sceneSelectedFileName: displayName(selected) || 'None' } : {}),
+		})
+		instance.checkFeedbacks('sceneSelectedFile')
+		queueDataRefresh(instance, 'scenes')
+	})
+	on('OnLiveScenesSceneChanged', (liveSceneId: unknown) => {
+		const id = valueToString(liveSceneId)
+		instance.SCENES_FILE_SELECTED_SCENE_ID = id
+		const selected = instance.SCENES_FILE_SELECTED_SCENES.find((scene) => stringId(scene) === id)
+		instance.SCENES_FILE_SELECTED_SCENE = selected ?? (id ? { Id: id } : {})
+		instance.setVariableValues({
+			sceneSelectedSceneId: id || 'None',
+			...(selected ? { sceneSelectedSceneName: displayName(selected) || 'None' } : {}),
+		})
+		instance.checkFeedbacks('sceneSelectedScene')
+		queueDataRefresh(instance, 'scenes')
+	})
+	on('OnSceneSnapshotUpdated', () => queueDataRefresh(instance, 'scenes'))
+	on('OnPlaylistPlay', (medialistId: unknown, item: unknown, position: number) => {
+		setMedialistState(instance, medialistId, item, position)
+		instance.setVariableValues({ medialistPlaying: true })
+	})
+	on('OnPlaylistStop', (medialistId: unknown) => {
+		setMedialistState(instance, medialistId)
+		instance.setVariableValues({ medialistPlaying: false })
+	})
+	on('OnLivePlaylistItemChanged', (medialistId: unknown, item: unknown, position: number) => {
+		setMedialistState(instance, medialistId, item, position)
+	})
+	on('OnLivePlaylistFileChanged', (medialist: unknown) => {
+		setSelectedMedialist(instance, medialist)
+	})
+	on('OnLivePlaylistItemAdded', () => queueDataRefresh(instance, 'medialist'))
+	on('OnLivePlaylistItemRemoved', () => queueDataRefresh(instance, 'medialist'))
+	on('OnLivePlaylistItemIndexChanged', () => queueDataRefresh(instance, 'medialist'))
+	on('OnLivePlaylistItemModified', (item: unknown) => {
+		setMedialistState(instance, '', item)
+		queueDataRefresh(instance, 'medialist')
+	})
+	on('OnPlaylistItemModified', () => queueDataRefresh(instance, 'medialist'))
+	on('OnPlaylistLoadingStateChanged', (medialist: unknown, isLoading: boolean) => {
+		instance.setVariableValues({
+			medialistLoading: Boolean(isLoading),
+			medialistSelectedId: stringId(medialist) || 'None',
+		})
+	})
+	on('OnLiveSourceChanged', (info: unknown) => {
+		const source = getField(info, 'mainSource', 'MainSource', 'sourceName', 'SourceName', 'source', 'Source')
+		const isComposition = getField(info, 'isComposition', 'IsComposition')
+		instance.setVariableValues({ signalrLiveSourceInfo: safeStringify(info) })
+		if (isRecord(info)) instance.VIDEO_MIXER = info
+		if (source !== undefined) {
+			instance.VIDEO_LIVE_SOURCE = String(source)
+			instance.setVariableValues({ videoLiveSource: String(source) })
+			instance.checkFeedbacks('videoLiveSource')
+		}
+		if (isComposition !== undefined) instance.setVariableValues({ videoMixerIsComposition: Boolean(isComposition) })
+	})
+	on('OnLiveSourceChanging', (info: unknown) => {
+		instance.setVariableValues({ signalrLiveSourceChanging: safeStringify(info) })
+	})
+	on('OnPilotedDeviceChanged', (info: unknown) => {
+		instance.setVariableValues({ signalrPilotedDevice: safeStringify(info) })
+	})
+	on('OnAssistViewedSceneChanged', (sceneInfo: unknown) => {
+		instance.setVariableValues({ signalrAssistViewedScene: safeStringify(sceneInfo) })
+	})
+	on('OnZoneAdded', (zone: unknown) => setCropZones(instance, upsertById(instance.SIGNALR_CROP_ZONES, zone)))
+	on('OnZoneDeleted', (zoneId: unknown) => setCropZones(instance, removeById(instance.SIGNALR_CROP_ZONES, zoneId)))
+	on('OnZoneUpdated', (zone: unknown) => setCropZones(instance, upsertById(instance.SIGNALR_CROP_ZONES, zone)))
+
+	for (const method of SIGNALR_RECEIVER_METHODS) {
+		if (!registered.has(method)) on(method, () => queueDataRefresh(instance, 'all'))
+	}
+
+	// Older builds did not include complete payloads, so reconcile only their related resource through HTTP.
+	const legacyRefreshTargets: Record<string, PollScope> = {
+		OnMultipleDisplaySetupChanged: 'video',
+		OnPreviewCompoChanged: 'composer',
+		OnPreviewCompoIdChanged: 'composer',
+		OnPreviewComposerFileChanged: 'composer',
+		OnPreviewComposerFileIdChanged: 'composer',
+		OnPreviewSceneChanged: 'scenes',
+		OnRoomAdded: 'application',
+		OnRoomDeleted: 'application',
+		OnRoomUpdated: 'application',
+		OnStaticTitleChanged: 'titler',
+		OnTitlerElementAdded: 'titler',
+		OnTitlerElementDeleted: 'titler',
+		OnTitlerElementsCleared: 'titler',
+		OnTitlerFileSelectedRowEdited: 'titler',
+		OnTitlerFileSelectedRowSelectionChanged: 'titler',
+		OnTitlerSelectedFileRowsCleared: 'titler',
+		OnTitlerSelectedFileRowsUpdated: 'titler',
+	}
+	for (const [legacyMethod, target] of Object.entries(legacyRefreshTargets)) {
+		on(legacyMethod, () => queueDataRefresh(instance, target, true))
+	}
+	on('OnSelectedZoneChanged', () => void SyncSignalRState(instance))
+}
+
+async function invokeForSync(
+	instance: MulticamInstance,
+	connection: signalR.HubConnection,
+	method: SignalRStateMethod,
+): Promise<{ ok: boolean; value?: any }> {
+	try {
+		return { ok: true, value: await connection.invoke(method) }
+	} catch (error: any) {
+		instance.log('debug', `SignalR sync ${method} unavailable: ${error?.message ?? error}`)
+		return { ok: false }
+	}
+}
+
+export async function SyncSignalRState(instance: MulticamInstance): Promise<void> {
+	const connection = instance._signalR
+	if (!connection || connection.state !== signalR.HubConnectionState.Connected) return
+
+	const methods = SIGNALR_STATE_METHODS
+	const results = await Promise.all(methods.map(async (method) => invokeForSync(instance, connection, method)))
+	const values = new Map(methods.map((method, index) => [method, results[index]]))
+
+	const application = values.get('GetCurrentApplication')
+	if (application?.ok) {
+		instance.RUNNING_APPLICATION = String(application.value ?? '')
+		instance.setVariableValues({ runningApp: application.value || 'None' })
+	}
+	const recordings = values.get('GetRecordings')
+	if (recordings?.ok) setPublisherRecordings(instance, recordings.value)
+	const lastRecording = values.get('GetLastRecording')
+	if (lastRecording?.ok) instance.setVariableValues({ signalrLastRecording: safeStringify(lastRecording.value) })
+	const workflows = values.get('GetWorkflows')
+	if (workflows?.ok) setPublisherWorkflows(instance, workflows.value)
+	const jobs = values.get('GetPublishingJobs')
+	if (jobs?.ok) setPublishingJobs(instance, jobs.value)
+	const recording = values.get('GetRecordingState')
+	if (recording?.ok) {
+		instance.RECORDING = Boolean(recording.value)
+		instance.setVariableValues({
+			recording: instance.RECORDING,
+			recordingState: instance.RECORDING ? 'Recording' : 'Stopped',
+		})
+	}
+	const liveExtract = values.get('GetLiveExtractState')
+	if (liveExtract?.ok) updateLiveExtract(instance, liveExtract.value)
+	const streaming = values.get('GetStreamingState')
+	if (streaming?.ok) instance.setVariableValues({ streamingAnyActive: Boolean(streaming.value) })
+	const microphone = values.get('GetUserSelectedMicrophone')
+	if (microphone?.ok) {
+		instance.SIGNALR_SELECTED_MICROPHONE = Number(microphone.value)
+		instance.setVariableValues({ signalrSelectedMicrophone: instance.SIGNALR_SELECTED_MICROPHONE })
+	}
+	const zoom = values.get('GetIsZoomFeatureEnabled')
+	if (zoom?.ok) {
+		instance.SIGNALR_ZOOM_ENABLED = Boolean(zoom.value)
+		instance.setVariableValues({ signalrZoomFeatureEnabled: instance.SIGNALR_ZOOM_ENABLED })
+	}
+	const zones = values.get('GetCropZones')
+	if (zones?.ok) setCropZones(instance, zones.value)
+	instance.checkAllFeedbacks()
+}
+
+export async function InitSignalR(instance: MulticamInstance): Promise<void> {
+	instance.log('debug', 'Initializing SignalR connection')
+	setConnectionState(instance, false)
+
+	const url = `http://${instance.config.host}:${instance.config.port}/signalr`
+	const options: signalR.IHttpConnectionOptions = {}
+	if (instance.config.specifyApiKey && instance.secrets.apiKey) {
+		options.headers = { 'x-apikey': instance.secrets.apiKey }
+	}
+	const connection = new signalR.HubConnectionBuilder()
+		.withUrl(url, options)
+		.withAutomaticReconnect({
+			nextRetryDelayInMilliseconds: (context) => Math.min(1000 * 2 ** context.previousRetryCount, 30000),
+		})
+		.configureLogging(instance.config.verbose ? signalR.LogLevel.Information : signalR.LogLevel.Warning)
+		.build()
+
+	instance._signalR = connection
+	registerSignalREvents(instance, connection)
+	connection.onclose((error) => {
+		if (instance._signalR !== connection) return
+		setConnectionState(instance, false)
+		instance.log('warn', `SignalR closed: ${error?.message ?? 'no error'}`)
+	})
+	connection.onreconnecting((error) => {
+		if (instance._signalR !== connection) return
+		setConnectionState(instance, false)
+		instance.log('warn', `SignalR reconnecting: ${error?.message ?? 'no error'}`)
+	})
+	connection.onreconnected((connectionId) => {
+		if (instance._signalR !== connection) return
+		setConnectionState(instance, true)
+		instance.log('info', `SignalR reconnected. connectionId=${connectionId ?? 'null'}`)
+		void (async () => {
+			await SyncSignalRState(instance)
+			// Events emitted during the disconnect are not replayed. Reconcile once, including HTTP-only state.
+			await runPollCycle(instance, { forceSignalRRefresh: true })
+		})()
+	})
+
+	try {
+		await connection.start()
+		if (instance._signalR !== connection) {
+			await connection.stop()
+			return
+		}
+		setConnectionState(instance, true)
+		instance.log('info', 'SignalR connected')
+		await SyncSignalRState(instance)
+	} catch (error: any) {
+		setConnectionState(instance, false)
+		instance.log('error', `SignalR failed to start: ${error?.message ?? error}`)
+	}
 }

--- a/src/signalr.ts
+++ b/src/signalr.ts
@@ -88,6 +88,69 @@ const pendingRefreshes = new WeakMap<
 	MulticamInstance,
 	{ targets: Set<PollScope | 'all'>; forceSignalRRefresh: boolean }
 >()
+type SignalRReconnectState = {
+	timer: NodeJS.Timeout | null
+	attempts: number
+}
+const signalRReconnectStates = new WeakMap<MulticamInstance, SignalRReconnectState>()
+const SIGNALR_RETRY_BASE_MS = 2000
+const SIGNALR_RETRY_MAX_MS = 30000
+
+function getSignalRReconnectState(instance: MulticamInstance): SignalRReconnectState {
+	let state = signalRReconnectStates.get(instance)
+	if (!state) {
+		state = { timer: null, attempts: 0 }
+		signalRReconnectStates.set(instance, state)
+	}
+	return state
+}
+
+export function cancelSignalRReconnect(instance: MulticamInstance): void {
+	const state = signalRReconnectStates.get(instance)
+	if (state?.timer) clearTimeout(state.timer)
+	signalRReconnectStates.delete(instance)
+}
+
+function scheduleSignalRReconnect(instance: MulticamInstance, connection: signalR.HubConnection): void {
+	if (instance._signalR !== connection || connection.state !== signalR.HubConnectionState.Disconnected) return
+
+	const state = getSignalRReconnectState(instance)
+	if (state.timer) return
+	const delay = Math.min(SIGNALR_RETRY_BASE_MS * 2 ** Math.min(state.attempts, 4), SIGNALR_RETRY_MAX_MS)
+	state.attempts++
+	instance.log('warn', `SignalR unavailable; retrying in ${Math.ceil(delay / 1000)}s`)
+	state.timer = setTimeout(() => {
+		state.timer = null
+		if (instance._signalR !== connection || connection.state !== signalR.HubConnectionState.Disconnected) return
+		void startSignalRConnection(instance, connection)
+	}, delay)
+}
+
+async function startSignalRConnection(instance: MulticamInstance, connection: signalR.HubConnection): Promise<void> {
+	if (instance._signalR !== connection || connection.state !== signalR.HubConnectionState.Disconnected) return
+	const isRetry = getSignalRReconnectState(instance).attempts > 0
+
+	try {
+		await connection.start()
+		if (instance._signalR !== connection) {
+			await connection.stop()
+			return
+		}
+		cancelSignalRReconnect(instance)
+		setConnectionState(instance, true)
+		instance.log('info', isRetry ? 'SignalR reconnected' : 'SignalR connected')
+		await SyncSignalRState(instance)
+		if (isRetry && instance._signalR === connection) {
+			// SignalR events aren't replayed after a disconnect, so reconcile all state once.
+			await runPollCycle(instance, { forceSignalRRefresh: true })
+		}
+	} catch (error: any) {
+		if (instance._signalR !== connection) return
+		setConnectionState(instance, false)
+		instance.log('error', `SignalR failed to start: ${error?.message ?? error}`)
+		scheduleSignalRReconnect(instance, connection)
+	}
+}
 
 function isRecord(value: unknown): value is RecordLike {
 	return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -759,6 +822,7 @@ export async function SyncSignalRState(instance: MulticamInstance): Promise<void
 
 export async function InitSignalR(instance: MulticamInstance): Promise<void> {
 	instance.log('debug', 'Initializing SignalR connection')
+	cancelSignalRReconnect(instance)
 	setConnectionState(instance, false)
 
 	const url = `http://${instance.config.host}:${instance.config.port}/signalr`
@@ -780,6 +844,7 @@ export async function InitSignalR(instance: MulticamInstance): Promise<void> {
 		if (instance._signalR !== connection) return
 		setConnectionState(instance, false)
 		instance.log('warn', `SignalR closed: ${error?.message ?? 'no error'}`)
+		scheduleSignalRReconnect(instance, connection)
 	})
 	connection.onreconnecting((error) => {
 		if (instance._signalR !== connection) return
@@ -788,6 +853,7 @@ export async function InitSignalR(instance: MulticamInstance): Promise<void> {
 	})
 	connection.onreconnected((connectionId) => {
 		if (instance._signalR !== connection) return
+		cancelSignalRReconnect(instance)
 		setConnectionState(instance, true)
 		instance.log('info', `SignalR reconnected. connectionId=${connectionId ?? 'null'}`)
 		void (async () => {
@@ -797,17 +863,5 @@ export async function InitSignalR(instance: MulticamInstance): Promise<void> {
 		})()
 	})
 
-	try {
-		await connection.start()
-		if (instance._signalR !== connection) {
-			await connection.stop()
-			return
-		}
-		setConnectionState(instance, true)
-		instance.log('info', 'SignalR connected')
-		await SyncSignalRState(instance)
-	} catch (error: any) {
-		setConnectionState(instance, false)
-		instance.log('error', `SignalR failed to start: ${error?.message ?? error}`)
-	}
+	await startSignalRConnection(instance, connection)
 }

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,16 +1,82 @@
-import type { CompanionStaticUpgradeScript } from '@companion-module/base'
-import type { ModuleConfig } from './config.js'
+import type { CompanionMigrationAction, CompanionStaticUpgradeScript } from '@companion-module/base'
+import type { ModuleConfig, ModuleSecrets } from './config.js'
 
-export const UpgradeScripts: CompanionStaticUpgradeScript<ModuleConfig>[] = [
-	/*
-	 * Place your upgrade scripts here
-	 * Remember that once it has been added it cannot be removed!
-	 */
-	// function (context, props) {
-	// 	return {
-	// 		updatedConfig: null,
-	// 		updatedActions: [],
-	// 		updatedFeedbacks: [],
-	// 	}
-	// },
+type LegacyModuleConfig = ModuleConfig & {
+	apiKey?: unknown
+}
+
+const migrateApiKeyToSecrets: CompanionStaticUpgradeScript<ModuleConfig, ModuleSecrets> = (context, props) => {
+	const currentConfig = (props.config ?? context.currentConfig) as LegacyModuleConfig
+	if (!Object.prototype.hasOwnProperty.call(currentConfig, 'apiKey')) {
+		return {
+			updatedConfig: null,
+			updatedSecrets: null,
+			updatedActions: [],
+			updatedFeedbacks: [],
+		}
+	}
+
+	const { apiKey, ...configWithoutApiKey } = currentConfig
+	const legacyApiKey = typeof apiKey === 'string' ? apiKey : ''
+	const shouldMigrateApiKey = legacyApiKey.length > 0 && !props.secrets?.apiKey
+
+	return {
+		updatedConfig: configWithoutApiKey,
+		updatedSecrets: shouldMigrateApiKey ? { ...(props.secrets ?? { apiKey: '' }), apiKey: legacyApiKey } : null,
+		updatedActions: [],
+		updatedFeedbacks: [],
+	}
+}
+
+const ISO_SOURCE_ACTION_IDS = new Set(['recordingIsoStartSource', 'recordingIsoStopSource'])
+
+function getLiteralStringOption(option: unknown): string | null {
+	if (typeof option === 'string') return option
+	if (
+		typeof option !== 'object' ||
+		option === null ||
+		!('isExpression' in option) ||
+		option.isExpression !== false ||
+		!('value' in option) ||
+		typeof option.value !== 'string'
+	) {
+		return null
+	}
+
+	return option.value
+}
+
+function migrateIsoSourceAction(action: CompanionMigrationAction): CompanionMigrationAction | null {
+	if (!ISO_SOURCE_ACTION_IDS.has(action.actionId)) return null
+
+	const legacyCamId = getLiteralStringOption(action.options.camId)
+	if (legacyCamId === null) return null
+
+	const match = /^CAM(\d+)$/i.exec(legacyCamId.trim())
+	if (!match) return null
+
+	const sourceNumber = Number(match[1])
+	if (!Number.isInteger(sourceNumber) || sourceNumber < 1 || sourceNumber > 40) return null
+
+	return {
+		...action,
+		options: {
+			...action.options,
+			camId: { value: `Source ${sourceNumber}`, isExpression: false },
+		},
+	}
+}
+
+const migrateIsoRecordingSources: CompanionStaticUpgradeScript<ModuleConfig, ModuleSecrets> = (_context, props) => ({
+	updatedConfig: null,
+	updatedSecrets: null,
+	updatedActions: props.actions
+		.map((action) => migrateIsoSourceAction(action))
+		.filter((action): action is CompanionMigrationAction => action !== null),
+	updatedFeedbacks: [],
+})
+
+export const UpgradeScripts: CompanionStaticUpgradeScript<ModuleConfig, ModuleSecrets>[] = [
+	migrateApiKeyToSecrets,
+	migrateIsoRecordingSources,
 ]

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,9 +1,11 @@
-import type { CompanionVariableDefinition, CompanionVariableValues } from '@companion-module/base'
+import type { CompanionVariableValues } from '@companion-module/base'
 
 import type { MulticamInstance } from './main.js'
 
+export type VariablesSchema = CompanionVariableValues
+
 export function UpdateVariableDefinitions(self: MulticamInstance): void {
-	const variables: CompanionVariableDefinition[] = []
+	const variables: Array<{ variableId: string; name: string }> = []
 
 	//computer name
 	variables.push({ variableId: 'computerName', name: 'Computer Name' })
@@ -18,8 +20,27 @@ export function UpdateVariableDefinitions(self: MulticamInstance): void {
 	variables.push({ variableId: 'runningApp', name: 'Running Application' })
 	//application auto/manual state
 	variables.push({ variableId: 'applicationAutoState', name: 'Application Auto/Manual State' })
-	//application snapshot
-	variables.push({ variableId: 'applicationSnapshot', name: 'Application Snapshot' })
+	variables.push({ variableId: 'rooms', name: 'Available Rooms' })
+	variables.push({ variableId: 'selected_room', name: 'Selected Room' })
+	variables.push({ variableId: 'selectedRoomId', name: 'Selected Room ID' })
+	variables.push({ variableId: 'applicationTemplates', name: 'Application Templates (JSON)' })
+
+	//audio variables
+	variables.push({ variableId: 'audioProfiles', name: 'Audio - Available Profiles' })
+	variables.push({ variableId: 'audioSelectedProfile', name: 'Audio - Selected Profile' })
+	variables.push({ variableId: 'audioSelectedProfileId', name: 'Audio - Selected Profile ID' })
+
+	//Conf variables
+	variables.push({ variableId: 'confAutomationMode', name: 'Conf - Automation Mode' })
+	variables.push({ variableId: 'confActiveMicrophones', name: 'Conf - Active Microphones' })
+	variables.push({ variableId: 'confDynamism', name: 'Conf - Dynamism' })
+	variables.push({ variableId: 'confPresetBank', name: 'Conf - Current Preset Bank' })
+	variables.push({ variableId: 'confPresetBankId', name: 'Conf - Current Preset Bank ID' })
+	variables.push({ variableId: 'confAutoTitling', name: 'Conf - Automatic Titling Enabled' })
+
+	//Insitu variables
+	variables.push({ variableId: 'insituActiveTags', name: 'Insitu - Active Tags' })
+	variables.push({ variableId: 'insituActiveLayout', name: 'Insitu - Active Layout' })
 
 	//composer variables
 	//composer selected file name and id
@@ -29,6 +50,38 @@ export function UpdateVariableDefinitions(self: MulticamInstance): void {
 	variables.push({ variableId: 'composerSelectedCompositionSceneName', name: 'Composer - Selected Composition Name' })
 	variables.push({ variableId: 'composerSelectedCompositionSceneId', name: 'Composer - Selected Composition ID' })
 
+	//Medialist variables
+	variables.push({ variableId: 'medialistSelectedName', name: 'Medialist - Selected Name' })
+	variables.push({ variableId: 'medialistSelectedId', name: 'Medialist - Selected ID' })
+	variables.push({ variableId: 'medialistSelectedMedia', name: 'Medialist - Selected Media (JSON)' })
+	variables.push({ variableId: 'medialistSelectedMediaName', name: 'Medialist - Selected Media Name' })
+	variables.push({ variableId: 'medialistSelectedMediaId', name: 'Medialist - Selected Media ID' })
+	variables.push({ variableId: 'medialistPlaying', name: 'Medialist - Playing' })
+	variables.push({ variableId: 'medialistLoading', name: 'Medialist - Loading' })
+	variables.push({ variableId: 'medialistPosition', name: 'Medialist - Playback Position' })
+
+	//Publisher variables
+	variables.push({ variableId: 'publisherRecordingCount', name: 'Publisher - Recording Count' })
+
+	//Radio variables
+	variables.push({ variableId: 'radioAutomationMode', name: 'Radio - Automation Mode' })
+	variables.push({ variableId: 'radioActiveMicrophones', name: 'Radio - Active Microphones' })
+	variables.push({ variableId: 'radioDynamism', name: 'Radio - Dynamism' })
+	variables.push({ variableId: 'radioPresetBank', name: 'Radio - Current Preset Bank' })
+	variables.push({ variableId: 'radioPresetBankId', name: 'Radio - Current Preset Bank ID' })
+	variables.push({ variableId: 'radioAutoTitling', name: 'Radio - Automatic Titling Enabled' })
+	variables.push({ variableId: 'radioAutomationVariables', name: 'Radio - Automation Variables (JSON)' })
+
+	//Recording variables
+	variables.push({ variableId: 'recording', name: 'Recording - Active' })
+	variables.push({ variableId: 'recordingState', name: 'Recording - State' })
+	variables.push({ variableId: 'recordingPaused', name: 'Recording - Paused' })
+	variables.push({ variableId: 'recordingLiveExtract', name: 'Recording - Live Extract Active' })
+	variables.push({
+		variableId: 'recordingLiveExtractSecondsRemaining',
+		name: 'Recording - Live Extract Seconds Remaining',
+	})
+
 	//SCENES
 	//selected scene file
 	variables.push({ variableId: 'sceneSelectedFileName', name: 'Scene - Selected File Name' })
@@ -37,12 +90,47 @@ export function UpdateVariableDefinitions(self: MulticamInstance): void {
 	variables.push({ variableId: 'sceneSelectedSceneName', name: 'Scene - Selected Scene Name' })
 	variables.push({ variableId: 'sceneSelectedSceneId', name: 'Scene - Selected Scene ID' })
 
+	//Streaming variables
+	variables.push({ variableId: 'streamingSelectedCatalog', name: 'Streaming - Selected Catalog' })
+	variables.push({ variableId: 'streamingSelectedCatalogId', name: 'Streaming - Selected Catalog ID' })
+	variables.push({ variableId: 'streamingActiveProfiles', name: 'Streaming - Active Profiles' })
+	variables.push({ variableId: 'streamingActiveProfileCount', name: 'Streaming - Active Profile Count' })
+	variables.push({ variableId: 'streamingAnyActive', name: 'Streaming - Any Profile Active' })
+
 	//titler variables
 	//selected file name and id
 	variables.push({ variableId: 'titlerSelectedFileName', name: 'Titler - Selected File Name' })
 	variables.push({ variableId: 'titlerSelectedFileId', name: 'Titler - Selected File ID' })
+	variables.push({ variableId: 'titlerElementStructures', name: 'Titler - Element Structures (JSON)' })
 
-	self.setVariableDefinitions(variables)
+	//Video / settings variables
+	variables.push({ variableId: 'videoLiveSource', name: 'Video - Live Source' })
+	variables.push({ variableId: 'videoMixerIsComposition', name: 'Video - Mixer is Composition' })
+	variables.push({ variableId: 'mediaConstraints', name: 'Settings - Media Constraints (JSON)' })
+
+	//SignalR
+	variables.push({ variableId: 'signalrConnected', name: 'SignalR - Connected' })
+	variables.push({ variableId: 'signalrLastEvent', name: 'SignalR - Last Event' })
+	variables.push({ variableId: 'signalrLastPayload', name: 'SignalR - Last Event Payload (JSON)' })
+	variables.push({ variableId: 'signalrRecordTime', name: 'SignalR - Recording Time' })
+	variables.push({ variableId: 'signalrLastRecording', name: 'SignalR - Last Recording (JSON)' })
+	variables.push({ variableId: 'signalrPublishingJobs', name: 'SignalR - Publishing Jobs (JSON)' })
+	variables.push({ variableId: 'signalrSelectedMicrophone', name: 'SignalR - User Selected Microphone' })
+	variables.push({ variableId: 'signalrMicrophoneState', name: 'SignalR - Microphone State (JSON)' })
+	variables.push({ variableId: 'signalrZoomFeatureEnabled', name: 'SignalR - Zoom Feature Enabled' })
+	variables.push({ variableId: 'signalrCropZones', name: 'SignalR - Crop Zones (JSON)' })
+	variables.push({ variableId: 'signalrNetworkShare', name: 'SignalR - Network Share (JSON)' })
+	variables.push({ variableId: 'signalrPagedRecordings', name: 'SignalR - Paged Recordings (JSON)' })
+	variables.push({ variableId: 'signalrAutomationAssistMessage', name: 'SignalR - Automation Assist Message' })
+	variables.push({ variableId: 'signalrAutoTitlingConfig', name: 'SignalR - Auto Titling Config (JSON)' })
+	variables.push({ variableId: 'signalrAutomationNotification', name: 'SignalR - Automation Notification (JSON)' })
+	variables.push({ variableId: 'signalrSocialMediaPost', name: 'SignalR - Social Media Post (JSON)' })
+	variables.push({ variableId: 'signalrLiveSourceInfo', name: 'SignalR - Live Source Info (JSON)' })
+	variables.push({ variableId: 'signalrLiveSourceChanging', name: 'SignalR - Pending Live Source Info (JSON)' })
+	variables.push({ variableId: 'signalrPilotedDevice', name: 'SignalR - Piloted Device (JSON)' })
+	variables.push({ variableId: 'signalrAssistViewedScene', name: 'SignalR - Assist Viewed Scene (JSON)' })
+
+	self.setVariableDefinitions(Object.fromEntries(variables.map(({ variableId, name }) => [variableId, { name }])))
 }
 
 export function CheckVariables(self: MulticamInstance): void {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,14 +1,10 @@
 {
-	"extends": "@companion-module/tools/tsconfig/node18/recommended",
+	"extends": "@companion-module/tools/tsconfig/node22/recommended-esm.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules/**", "src/**/*spec.ts", "src/**/__tests__/*", "src/**/__mocks__/*"],
 	"compilerOptions": {
 		"outDir": "./dist",
-		"baseUrl": "./",
-		"paths": {
-			"*": ["./node_modules/*"]
-		},
-		"module": "Node16",
-		"moduleResolution": "Node16"
+		"rootDir": "./src",
+		"verbatimModuleSyntax": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@companion-module/tools/tsconfig/node18/recommended",
+	"extends": "./tsconfig.build.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules/**"],
 	"compilerOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,44 +5,34 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@companion-module/base@npm:~1.12.0":
-  version: 1.12.1
-  resolution: "@companion-module/base@npm:1.12.1"
+"@companion-module/base@npm:2.1.2":
+  version: 2.1.2
+  resolution: "@companion-module/base@npm:2.1.2"
   dependencies:
-    ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
-    ejson: "npm:^2.2.3"
-    eventemitter3: "npm:^5.0.1"
-    mimic-fn: "npm:^3.1.0"
-    nanoid: "npm:^3.3.11"
-    p-queue: "npm:^6.6.2"
-    p-timeout: "npm:^4.1.0"
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/11e67f87ba7f1dff830247882638da7cbc07d70ae47c606f43876ed183657b81ac7264e771e79735486d93c9845b0f28cfc8283d5d24b1b9eeb13a8e5b82db9d
+  checksum: 10c0/3c77e872026d0191f741ba7c95fdf58c749ffcfb0c1d4cc65f0eca95f3375453e24da78dca5a78bc9b6c6e0924e6b549d2f30b350679c496666d43b7232885a2
   languageName: node
   linkType: hard
 
-"@companion-module/tools@npm:^2.7.2":
-  version: 2.7.2
-  resolution: "@companion-module/tools@npm:2.7.2"
+"@companion-module/tools@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@companion-module/tools@npm:3.0.1"
   dependencies:
-    "@eslint/js": "npm:^9.39.3"
+    "@eslint/js": "npm:^9.39.4"
+    esbuild: "npm:^0.27.7"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-n: "npm:^17.24.0"
     eslint-plugin-prettier: "npm:^5.5.5"
-    find-up: "npm:^7.0.0"
-    parse-author: "npm:^2.0.0"
+    find-up: "npm:^8.0.0"
     semver: "npm:^7.7.4"
-    tar: "npm:^7.5.9"
-    webpack: "npm:^5.105.2"
-    webpack-cli: "npm:^6.0.1"
+    tar: "npm:^7.5.13"
     zx: "npm:^8.8.5"
   peerDependencies:
-    "@companion-module/base": ^1.12.0 || ^2.0.0
+    "@companion-module/base": ^2.0.0
     "@companion-surface/base": ^1.0.0
-    eslint: ^9.36.0
-    prettier: ^3.6.2
-    typescript-eslint: ^8.44.1
+    eslint: ^9.39.3 || ^10.2.0
+    prettier: ^3.8.1
+    typescript-eslint: ^8.56.1
   peerDependenciesMeta:
     "@companion-module/base":
       optional: true
@@ -55,19 +45,193 @@ __metadata:
     typescript-eslint:
       optional: true
   bin:
-    companion-generate-manifest: scripts/generate-connection-manifest.js
-    companion-module-build: scripts/build-connection.js
-    companion-module-check: scripts/check-connection.js
-    companion-surface-build: scripts/build-surface.js
-    companion-surface-check: scripts/check-surface.js
-  checksum: 10c0/6942e52f1b89781bf48446834b36ce3d5256d885620926ec59363fa0bf238511330dde4a50f5176e8f70ff8fa5c9c44308585320a0a71e89417a93458d3edd48
+    companion-module-build: ./dist/scripts/build-connection.js
+    companion-module-check: ./dist/scripts/check-connection.js
+    companion-surface-build: ./dist/scripts/build-surface.js
+    companion-surface-check: ./dist/scripts/check-surface.js
+  checksum: 10c0/fd7730bd5c0c5fc98204ee59f09e763174538866bfd822bdd9415c7cc1d461dc69ce0d04b6b023c679580b9d0b8443c28e7bfc143faf5962e29c4ee753b385f4
   languageName: node
   linkType: hard
 
-"@discoveryjs/json-ext@npm:^0.6.1":
-  version: 0.6.3
-  resolution: "@discoveryjs/json-ext@npm:0.6.3"
-  checksum: 10c0/778a9f9d5c3696da3c1f9fa4186613db95a1090abbfb6c2601430645c0d0158cd5e4ba4f32c05904e2dd2747d57710f6aab22bd2f8aa3c4e8feab9b247c65d85
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -93,6 +257,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.9.1":
+  version: 4.10.1
+  resolution: "@eslint-community/eslint-utils@npm:4.10.1"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/b514586655698bc6b74db72a496c77e813c78b63e36a83429845ac7057dd77113b0b6c31e6e590d5baaeee2abae6ea22363a41209bcafa078d895ab83ce83011
+  languageName: node
+  linkType: hard
+
 "@eslint-community/regexpp@npm:^4.11.0":
   version: 4.12.1
   resolution: "@eslint-community/regexpp@npm:4.12.1"
@@ -100,7 +275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.12.1":
+"@eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2":
   version: 4.12.2
   resolution: "@eslint-community/regexpp@npm:4.12.2"
   checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
@@ -153,10 +328,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.39.4, @eslint/js@npm:^9.39.3":
+"@eslint/js@npm:9.39.4":
   version: 9.39.4
   resolution: "@eslint/js@npm:9.39.4"
   checksum: 10c0/5aa7dea2cbc5decf7f5e3b0c6f86a084ccee0f792d288ca8e839f8bc1b64e03e227068968e49b26096e6f71fd857ab6e42691d1b993826b9a3883f1bdd7a0e46
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:^9.39.4":
+  version: 9.39.5
+  resolution: "@eslint/js@npm:9.39.5"
+  checksum: 10c0/49894e98ba313a7d3bfb1b20d55c0f9826be45a7db876fd84e533ac7f101b1d95b51cd22c6a6db3a45066b9c0d068c31b4a22fa0db8a6cc8744a25540efdb824
   languageName: node
   linkType: hard
 
@@ -227,50 +409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.5":
-  version: 0.3.12
-  resolution: "@jridgewell/gen-mapping@npm:0.3.12"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
-    "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10c0/32f771ae2467e4d440be609581f7338d786d3d621bac3469e943b9d6d116c23c4becb36f84898a92bbf2f3c0511365c54a945a3b86a83141547a2a360a5ec0c7
-  languageName: node
-  linkType: hard
-
-"@jridgewell/resolve-uri@npm:^3.1.0":
-  version: 3.1.2
-  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
-  checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
-  languageName: node
-  linkType: hard
-
-"@jridgewell/source-map@npm:^0.3.3":
-  version: 0.3.10
-  resolution: "@jridgewell/source-map@npm:0.3.10"
-  dependencies:
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-  checksum: 10c0/cf6a51808bc710eb91a9e6c5e250c1af5714299c8de3db2b74e273a27ba7313f37c198ba332a512b7657fa23fed125c0147bfb1b925cadc9697a89cebecad0d8
-  languageName: node
-  linkType: hard
-
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
-  version: 1.5.4
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.4"
-  checksum: 10c0/c5aab3e6362a8dd94ad80ab90845730c825fc4c8d9cf07ebca7a2eb8a832d155d62558800fc41d42785f989ddbb21db6df004d1786e8ecb65e428ab8dff71309
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
-  version: 0.3.29
-  resolution: "@jridgewell/trace-mapping@npm:0.3.29"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10c0/fb547ba31658c4d74eb17e7389f4908bf7c44cef47acb4c5baa57289daf68e6fe53c639f41f751b3923aca67010501264f70e7b49978ad1f040294b22c37b333
-  languageName: node
-  linkType: hard
-
 "@microsoft/signalr@npm:^10.0.0":
   version: 10.0.0
   resolution: "@microsoft/signalr@npm:10.0.0"
@@ -284,53 +422,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.9":
-  version: 0.2.9
-  resolution: "@pkgr/core@npm:0.2.9"
-  checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
+"@pkgr/core@npm:^0.3.6":
+  version: 0.3.6
+  resolution: "@pkgr/core@npm:0.3.6"
+  checksum: 10c0/153f0f4563f505faeba13c733efa0e05e467ce1c6b941055a5fd3b4560da60fbf1dff4b11da0075f034ddda11f2842b90395f60895dde5825875b616edccc11c
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.7":
-  version: 3.7.7
-  resolution: "@types/eslint-scope@npm:3.7.7"
-  dependencies:
-    "@types/eslint": "npm:*"
-    "@types/estree": "npm:*"
-  checksum: 10c0/a0ecbdf2f03912679440550817ff77ef39a30fa8bfdacaf6372b88b1f931828aec392f52283240f0d648cf3055c5ddc564544a626bcf245f3d09fcb099ebe3cc
-  languageName: node
-  linkType: hard
-
-"@types/eslint@npm:*":
-  version: 9.6.1
-  resolution: "@types/eslint@npm:9.6.1"
-  dependencies:
-    "@types/estree": "npm:*"
-    "@types/json-schema": "npm:*"
-  checksum: 10c0/69ba24fee600d1e4c5abe0df086c1a4d798abf13792d8cfab912d76817fe1a894359a1518557d21237fbaf6eda93c5ab9309143dee4c59ef54336d1b3570420e
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:*, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:^1.0.6":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:*":
-  version: 24.0.10
-  resolution: "@types/node@npm:24.0.10"
-  dependencies:
-    undici-types: "npm:~7.8.0"
-  checksum: 10c0/11dbd869d3e12ee7b7818113588950e538783e45d227122174c763cb05977defbd1e01b44b5ccd4b8997e42c3df7f7b83c6ee05cfa43d924c8882886bc5f6582
   languageName: node
   linkType: hard
 
@@ -343,201 +452,138 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/ast@npm:1.14.1"
+"@typescript-eslint/eslint-plugin@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.65.0"
   dependencies:
-    "@webassemblyjs/helper-numbers": "npm:1.13.2"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-  checksum: 10c0/67a59be8ed50ddd33fbb2e09daa5193ac215bf7f40a9371be9a0d9797a114d0d1196316d2f3943efdb923a3d809175e1563a3cb80c814fb8edccd1e77494972b
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/floating-point-hex-parser@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.13.2"
-  checksum: 10c0/0e88bdb8b50507d9938be64df0867f00396b55eba9df7d3546eb5dc0ca64d62e06f8d881ec4a6153f2127d0f4c11d102b6e7d17aec2f26bb5ff95a5e60652412
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-api-error@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/helper-api-error@npm:1.13.2"
-  checksum: 10c0/31be497f996ed30aae4c08cac3cce50c8dcd5b29660383c0155fce1753804fc55d47fcba74e10141c7dd2899033164e117b3bcfcda23a6b043e4ded4f1003dfb
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-buffer@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/helper-buffer@npm:1.14.1"
-  checksum: 10c0/0d54105dc373c0fe6287f1091e41e3a02e36cdc05e8cf8533cdc16c59ff05a646355415893449d3768cda588af451c274f13263300a251dc11a575bc4c9bd210
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-numbers@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/helper-numbers@npm:1.13.2"
-  dependencies:
-    "@webassemblyjs/floating-point-hex-parser": "npm:1.13.2"
-    "@webassemblyjs/helper-api-error": "npm:1.13.2"
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 10c0/9c46852f31b234a8fb5a5a9d3f027bc542392a0d4de32f1a9c0075d5e8684aa073cb5929b56df565500b3f9cc0a2ab983b650314295b9bf208d1a1651bfc825a
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-wasm-bytecode@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.13.2"
-  checksum: 10c0/c4355d14f369b30cf3cbdd3acfafc7d0488e086be6d578e3c9780bd1b512932352246be96e034e2a7fcfba4f540ec813352f312bfcbbfe5bcfbf694f82ccc682
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-wasm-section@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/helper-wasm-section@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-buffer": "npm:1.14.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/wasm-gen": "npm:1.14.1"
-  checksum: 10c0/1f9b33731c3c6dbac3a9c483269562fa00d1b6a4e7133217f40e83e975e636fd0f8736e53abd9a47b06b66082ecc976c7384391ab0a68e12d509ea4e4b948d64
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/ieee754@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/ieee754@npm:1.13.2"
-  dependencies:
-    "@xtuc/ieee754": "npm:^1.2.0"
-  checksum: 10c0/2e732ca78c6fbae3c9b112f4915d85caecdab285c0b337954b180460290ccd0fb00d2b1dc4bb69df3504abead5191e0d28d0d17dfd6c9d2f30acac8c4961c8a7
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/leb128@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/leb128@npm:1.13.2"
-  dependencies:
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 10c0/dad5ef9e383c8ab523ce432dfd80098384bf01c45f70eb179d594f85ce5db2f80fa8c9cba03adafd85684e6d6310f0d3969a882538975989919329ac4c984659
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/utf8@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/utf8@npm:1.13.2"
-  checksum: 10c0/d3fac9130b0e3e5a1a7f2886124a278e9323827c87a2b971e6d0da22a2ba1278ac9f66a4f2e363ecd9fac8da42e6941b22df061a119e5c0335f81006de9ee799
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-edit@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-edit@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-buffer": "npm:1.14.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/helper-wasm-section": "npm:1.14.1"
-    "@webassemblyjs/wasm-gen": "npm:1.14.1"
-    "@webassemblyjs/wasm-opt": "npm:1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:1.14.1"
-    "@webassemblyjs/wast-printer": "npm:1.14.1"
-  checksum: 10c0/5ac4781086a2ca4b320bdbfd965a209655fe8a208ca38d89197148f8597e587c9a2c94fb6bd6f1a7dbd4527c49c6844fcdc2af981f8d793a97bf63a016aa86d2
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-gen@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-gen@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/ieee754": "npm:1.13.2"
-    "@webassemblyjs/leb128": "npm:1.13.2"
-    "@webassemblyjs/utf8": "npm:1.13.2"
-  checksum: 10c0/d678810d7f3f8fecb2e2bdadfb9afad2ec1d2bc79f59e4711ab49c81cec578371e22732d4966f59067abe5fba8e9c54923b57060a729d28d408e608beef67b10
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-opt@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-opt@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-buffer": "npm:1.14.1"
-    "@webassemblyjs/wasm-gen": "npm:1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:1.14.1"
-  checksum: 10c0/515bfb15277ee99ba6b11d2232ddbf22aed32aad6d0956fe8a0a0a004a1b5a3a277a71d9a3a38365d0538ac40d1b7b7243b1a244ad6cd6dece1c1bb2eb5de7ee
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-parser@npm:1.14.1, @webassemblyjs/wasm-parser@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-parser@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-api-error": "npm:1.13.2"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/ieee754": "npm:1.13.2"
-    "@webassemblyjs/leb128": "npm:1.13.2"
-    "@webassemblyjs/utf8": "npm:1.13.2"
-  checksum: 10c0/95427b9e5addbd0f647939bd28e3e06b8deefdbdadcf892385b5edc70091bf9b92fa5faac3fce8333554437c5d85835afef8c8a7d9d27ab6ba01ffab954db8c6
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wast-printer@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wast-printer@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 10c0/8d7768608996a052545251e896eac079c98e0401842af8dd4de78fba8d90bd505efb6c537e909cd6dae96e09db3fa2e765a6f26492553a675da56e2db51f9d24
-  languageName: node
-  linkType: hard
-
-"@webpack-cli/configtest@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@webpack-cli/configtest@npm:3.0.1"
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@typescript-eslint/scope-manager": "npm:8.65.0"
+    "@typescript-eslint/type-utils": "npm:8.65.0"
+    "@typescript-eslint/utils": "npm:8.65.0"
+    "@typescript-eslint/visitor-keys": "npm:8.65.0"
+    ignore: "npm:^7.0.5"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    webpack: ^5.82.0
-    webpack-cli: 6.x.x
-  checksum: 10c0/edd24ecfc429298fe86446f7d7daedfe82d72e7f6236c81420605484fdadade5d59c6bcef3d76bd724e11d9727f74e75de183223ae62d3a568b2d54199688cbe
+    "@typescript-eslint/parser": ^8.65.0
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/1d9ddad417b43037c35c91a7c30bfc0015ccc40da57fe9faadae97fbaee6031a539a35265a9933d3bb946f307c397b7a00953806339576a721d619695a972079
   languageName: node
   linkType: hard
 
-"@webpack-cli/info@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@webpack-cli/info@npm:3.0.1"
+"@typescript-eslint/parser@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/parser@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.65.0"
+    "@typescript-eslint/types": "npm:8.65.0"
+    "@typescript-eslint/typescript-estree": "npm:8.65.0"
+    "@typescript-eslint/visitor-keys": "npm:8.65.0"
+    debug: "npm:^4.4.3"
   peerDependencies:
-    webpack: ^5.82.0
-    webpack-cli: 6.x.x
-  checksum: 10c0/b23b94e7dc8c93e79248f20d5f1bd0fbb7b9ba4b012803e2fdc5440b8f2ee1f3eca7f4933bbca346c8168673bf572b1858169a3cb2c17d9b8bcd833d480c2170
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/b3f5333abe5dfb08b53b89c824d045d96d5eb5798fab45eeedfaab72e4ce133a82fb4ebbc1acf79098aac9b08f7acc119fe0edd63ac2f91d80c98f5ca87c41e0
   languageName: node
   linkType: hard
 
-"@webpack-cli/serve@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@webpack-cli/serve@npm:3.0.1"
+"@typescript-eslint/project-service@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/project-service@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.65.0"
+    "@typescript-eslint/types": "npm:^8.65.0"
+    debug: "npm:^4.4.3"
   peerDependencies:
-    webpack: ^5.82.0
-    webpack-cli: 6.x.x
-  peerDependenciesMeta:
-    webpack-dev-server:
-      optional: true
-  checksum: 10c0/65245e45bfa35e11a5b30631b99cfed0c1b39b2cc8320fa2d2a4185264535618827d349ec032c58af4201d6236cbc43bec894fcb840fdd06314611537a80e210
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/56d8f598f1bb6ca892ff79320bd1aa134eefa05cf0bad4932c44518475a8bccf0c9027ae2177b3c1761496c8107236b81dd93f67d09093c2242f07f3f2063c1f
   languageName: node
   linkType: hard
 
-"@xtuc/ieee754@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@xtuc/ieee754@npm:1.2.0"
-  checksum: 10c0/a8565d29d135039bd99ae4b2220d3e167d22cf53f867e491ed479b3f84f895742d0097f935b19aab90265a23d5d46711e4204f14c479ae3637fbf06c4666882f
+"@typescript-eslint/scope-manager@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.65.0"
+    "@typescript-eslint/visitor-keys": "npm:8.65.0"
+  checksum: 10c0/303bae83a2243e742fcf86bef0b67615dc8915d2dd40268b796e2f49a40057b05de41608846aa362ad77e2d6976ec3cf30f1cdf245c1e39d18fd8ce91ae38c5c
   languageName: node
   linkType: hard
 
-"@xtuc/long@npm:4.2.2":
-  version: 4.2.2
-  resolution: "@xtuc/long@npm:4.2.2"
-  checksum: 10c0/8582cbc69c79ad2d31568c412129bf23d2b1210a1dfb60c82d5a1df93334da4ee51f3057051658569e2c196d8dc33bc05ae6b974a711d0d16e801e1d0647ccd1
+"@typescript-eslint/tsconfig-utils@npm:8.65.0, @typescript-eslint/tsconfig-utils@npm:^8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.65.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/5b897bbba4584ee67c7a0bc0b4b6cbf8db2cb5997d5ab8f07fae692315dd51cabcc7116c609a94a162747dd267118b7a0f1c8fb29d71210ad38549e4b8b6adb1
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/type-utils@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.65.0"
+    "@typescript-eslint/typescript-estree": "npm:8.65.0"
+    "@typescript-eslint/utils": "npm:8.65.0"
+    debug: "npm:^4.4.3"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/05a1a1283020f63eac3cb6202afd08459531a4522a85ceb0f5789f2902df7c180565f65f217cc780127888b7113b1c8c34aa6bfd7020d568f01a17f290216e9b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.65.0, @typescript-eslint/types@npm:^8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/types@npm:8.65.0"
+  checksum: 10c0/919b6d96111ea26f09c6cb1121fbba915147761be3fbf9c4de5b200faa2891087ebdcfd2f4a1f27a4c6153daeefc7448147c651a074b3ec70440f3f8c1092a81
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.65.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.65.0"
+    "@typescript-eslint/types": "npm:8.65.0"
+    "@typescript-eslint/visitor-keys": "npm:8.65.0"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/578ff5247f17865277badfe13362a82ba82c8bb11aaa78323933895e0ba0fc02788ae6aa9bd84bc8287660004a76231341977a3188b399c776b7e713c5054239
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/utils@npm:8.65.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.65.0"
+    "@typescript-eslint/types": "npm:8.65.0"
+    "@typescript-eslint/typescript-estree": "npm:8.65.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/258775532bb23bfeccb7ef25369a62b5fcf48f633af178830113d5aea6d0e968ad67a63b3371206151eb6a8dca0a3381f7efa07958fd8063505e1a53e470a439
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.65.0":
+  version: 8.65.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.65.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/f50cf2da4077f8eebfd56658ede17dfbf2e39875dc53562f5c1bc6e9835a0b4b00e0e0255e2dc3488234aca1f783d89beb084c417b22027520bf015a7b59ffb8
   languageName: node
   linkType: hard
 
@@ -550,15 +596,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-import-phases@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "acorn-import-phases@npm:1.0.4"
-  peerDependencies:
-    acorn: ^8.14.0
-  checksum: 10c0/338eb46fc1aed5544f628344cb9af189450b401d152ceadbf1f5746901a5d923016cd0e7740d5606062d374fdf6941c29bb515d2bd133c4f4242d5d4cd73a3c7
-  languageName: node
-  linkType: hard
-
 "acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -568,46 +605,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.14.0, acorn@npm:^8.15.0":
+"acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
     acorn: bin/acorn
   checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.16.0":
-  version: 8.16.0
-  resolution: "acorn@npm:8.16.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
-  languageName: node
-  linkType: hard
-
-"ajv-formats@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "ajv-formats@npm:2.1.1"
-  dependencies:
-    ajv: "npm:^8.0.0"
-  peerDependencies:
-    ajv: ^8.0.0
-  peerDependenciesMeta:
-    ajv:
-      optional: true
-  checksum: 10c0/e43ba22e91b6a48d96224b83d260d3a3a561b42d391f8d3c6d2c1559f9aa5b253bfb306bc94bbeca1d967c014e15a6efe9a207309e95b3eaae07fcbcdc2af662
-  languageName: node
-  linkType: hard
-
-"ajv-keywords@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "ajv-keywords@npm:5.1.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-  peerDependencies:
-    ajv: ^8.8.2
-  checksum: 10c0/18bec51f0171b83123ba1d8883c126e60c6f420cef885250898bf77a8d3e65e3bfb9e8564f497e30bdbe762a83e0d144a36931328616a973ee669dc74d4a9590
   languageName: node
   linkType: hard
 
@@ -620,18 +623,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/67966499dd272ecde1c2e467084411132891523d057487587879d39ac04207f4351b7b2324c83198013967fbfa632c1612adc960114a30770fbe07a0773b32c2
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.0, ajv@npm:^8.17.1, ajv@npm:^8.9.0":
-  version: 8.18.0
-  resolution: "ajv@npm:8.18.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
   languageName: node
   linkType: hard
 
@@ -651,13 +642,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"author-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "author-regex@npm:1.0.0"
-  checksum: 10c0/3f3a5ad6660be010bd5b979fac180f435bd9615e81db2b1cdac081eb3f639461f6c3927ced956e377a5c91cc789e3de3a3e900e296c1423971043c8fd8be0b73
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -669,15 +653,6 @@ __metadata:
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
   checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
-  languageName: node
-  linkType: hard
-
-"baseline-browser-mapping@npm:^2.9.0":
-  version: 2.9.19
-  resolution: "baseline-browser-mapping@npm:2.9.19"
-  bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/569928db78bcd081953d7db79e4243a59a579a34b4ae1806b9b42d3b7f84e5bc40e6e82ae4fa06e7bef8291bf747b33b3f9ef5d3c6e1e420cb129d9295536129
   languageName: node
   linkType: hard
 
@@ -700,39 +675,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.28.1":
-  version: 4.28.1
-  resolution: "browserslist@npm:4.28.1"
-  dependencies:
-    baseline-browser-mapping: "npm:^2.9.0"
-    caniuse-lite: "npm:^1.0.30001759"
-    electron-to-chromium: "npm:^1.5.263"
-    node-releases: "npm:^2.0.27"
-    update-browserslist-db: "npm:^1.2.0"
-  bin:
-    browserslist: cli.js
-  checksum: 10c0/545a5fa9d7234e3777a7177ec1e9134bb2ba60a69e6b95683f6982b1473aad347c77c1264ccf2ac5dea609a9731fbfbda6b85782bdca70f80f86e28a402504bd
-  languageName: node
-  linkType: hard
-
-"buffer-from@npm:^1.0.0":
-  version: 1.1.2
-  resolution: "buffer-from@npm:1.1.2"
-  checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
-  languageName: node
-  linkType: hard
-
 "callsites@npm:^3.0.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001766
-  resolution: "caniuse-lite@npm:1.0.30001766"
-  checksum: 10c0/cecc8f9a3758c486fc68434a3cca5f4ca7077db5ac9cdb1689786abf63c4aa9891bf70f2df2c3e549d5e284e8da36a218d0e131ebb26dd59280bc99db49640f6
   languageName: node
   linkType: hard
 
@@ -750,24 +696,6 @@ __metadata:
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
-  languageName: node
-  linkType: hard
-
-"chrome-trace-event@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "chrome-trace-event@npm:1.0.4"
-  checksum: 10c0/3058da7a5f4934b87cf6a90ef5fb68ebc5f7d06f143ed5a4650208e5d7acae47bc03ec844b29fbf5ba7e46e8daa6acecc878f7983a4f4bb7271593da91e61ff5
-  languageName: node
-  linkType: hard
-
-"clone-deep@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "clone-deep@npm:4.0.1"
-  dependencies:
-    is-plain-object: "npm:^2.0.4"
-    kind-of: "npm:^6.0.2"
-    shallow-clone: "npm:^3.0.0"
-  checksum: 10c0/637753615aa24adf0f2d505947a1bb75e63964309034a1cf56ba4b1f30af155201edd38d26ffe26911adaae267a3c138b344a4947d39f5fc1b6d6108125aa758
   languageName: node
   linkType: hard
 
@@ -794,27 +722,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.14":
-  version: 2.0.20
-  resolution: "colorette@npm:2.0.20"
-  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
-  languageName: node
-  linkType: hard
-
-"commander@npm:^12.1.0":
-  version: 12.1.0
-  resolution: "commander@npm:12.1.0"
-  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
-  languageName: node
-  linkType: hard
-
-"commander@npm:^2.20.0":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -822,7 +729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -833,7 +740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.1, debug@npm:^4.3.2":
+"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -852,20 +759,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejson@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "ejson@npm:2.2.3"
-  checksum: 10c0/648ea347f5e57441b7b9341adc6de244445b6da1d0e7747ea7a083f906299b92e4c44fc29e6de0b240d8fa4a73159e85f9367780d7af2ecbc50aae8a4e4961ae
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.5.263":
-  version: 1.5.282
-  resolution: "electron-to-chromium@npm:1.5.282"
-  checksum: 10c0/b970db002c3fd9b89faacd0f3752b868e16619fb720f1ac5975e4d93f8cf6e564762e05d647ea02246231342c105a37b886c5e4a6608e6987076d8e1a357ad8c
-  languageName: node
-  linkType: hard
-
 "enhanced-resolve@npm:^5.17.1":
   version: 5.18.4
   resolution: "enhanced-resolve@npm:5.18.4"
@@ -876,36 +769,92 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.20.0":
-  version: 5.21.0
-  resolution: "enhanced-resolve@npm:5.21.0"
+"esbuild@npm:^0.27.7":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
   dependencies:
-    graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.3.3"
-  checksum: 10c0/8d25b9eb7cbaaf6bac7ca52cefb6aa8a723a3cea754aa3c52f269bdae3b6d5f3219fadbaf4362ed7d53f027e0b83bfbeb4c646640123cf62e6dbe52f28604c77
-  languageName: node
-  linkType: hard
-
-"envinfo@npm:^7.14.0":
-  version: 7.14.0
-  resolution: "envinfo@npm:7.14.0"
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
   bin:
-    envinfo: dist/cli.js
-  checksum: 10c0/059a031eee101e056bd9cc5cbfe25c2fab433fe1780e86cf0a82d24a000c6931e327da6a8ffb3dce528a24f83f256e7efc0b36813113eff8fdc6839018efe327
-  languageName: node
-  linkType: hard
-
-"es-module-lexer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "es-module-lexer@npm:2.0.0"
-  checksum: 10c0/ae78dbbd43035a4b972c46cfb6877e374ea290adfc62bc2f5a083fea242c0b2baaab25c5886af86be55f092f4a326741cb94334cd3c478c383fdc8a9ec5ff817
-  languageName: node
-  linkType: hard
-
-"escalade@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "escalade@npm:3.2.0"
-  checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
+    esbuild: bin/esbuild
+  checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
   languageName: node
   linkType: hard
 
@@ -971,11 +920,11 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-prettier@npm:^5.5.5":
-  version: 5.5.5
-  resolution: "eslint-plugin-prettier@npm:5.5.5"
+  version: 5.5.6
+  resolution: "eslint-plugin-prettier@npm:5.5.6"
   dependencies:
     prettier-linter-helpers: "npm:^1.0.1"
-    synckit: "npm:^0.11.12"
+    synckit: "npm:^0.11.13"
   peerDependencies:
     "@types/eslint": ">=8.0.0"
     eslint: ">=8.0.0"
@@ -986,17 +935,7 @@ __metadata:
       optional: true
     eslint-config-prettier:
       optional: true
-  checksum: 10c0/091449b28c77ab2efbbf674e977181f2c8453d95a4df68218bddd87a4dfaa9ecc4eda60164e416f5986fb5d577e66e8d8e1e23d81e8555f8d735375598b03257
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:5.1.1":
-  version: 5.1.1
-  resolution: "eslint-scope@npm:5.1.1"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^4.1.1"
-  checksum: 10c0/d30ef9dc1c1cbdece34db1539a4933fe3f9b14e1ffb27ecc85987902ee663ad7c9473bbd49a9a03195a373741e62e2f807c4938992e019b511993d163450e70a
+  checksum: 10c0/af37126c947ff3e87ff1ea76408db8cb1c7da966ebdaba68c6dd5924da7eb1b43b1abc4796d753a97b1bc26ea94c5497093e6ab9f8588fffe558d5a554e19bbf
   languageName: node
   linkType: hard
 
@@ -1021,6 +960,13 @@ __metadata:
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
   checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "eslint-visitor-keys@npm:5.0.1"
+  checksum: 10c0/16190bdf2cbae40a1109384c94450c526a79b0b9c3cb21e544256ed85ac48a4b84db66b74a6561d20fe6ab77447f150d711c2ad5ad74df4fcc133736bce99678
   languageName: node
   linkType: hard
 
@@ -1102,13 +1048,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estraverse@npm:^4.1.1":
-  version: 4.3.0
-  resolution: "estraverse@npm:4.3.0"
-  checksum: 10c0/9cb46463ef8a8a4905d3708a652d60122a0c20bb58dec7e0e12ab0e7235123d74214fc0141d743c381813e1b992767e2708194f6f6e0f9fd00c1b4e0887b8b6d
-  languageName: node
-  linkType: hard
-
 "estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
   version: 5.3.0
   resolution: "estraverse@npm:5.3.0"
@@ -1127,27 +1066,6 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^4.0.4":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "eventemitter3@npm:5.0.1"
-  checksum: 10c0/4ba5c00c506e6c786b4d6262cfbce90ddc14c10d4667e5c83ae993c9de88aa856033994dd2b35b83e8dc1170e224e66a319fa80adc4c32adcd2379bbc75da814
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -1186,17 +1104,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
-  languageName: node
-  linkType: hard
-
-"fastest-levenshtein@npm:^1.0.12":
-  version: 1.0.16
-  resolution: "fastest-levenshtein@npm:1.0.16"
-  checksum: 10c0/7e3d8ae812a7f4fdf8cad18e9cde436a39addf266a5986f653ea0d81e0de0900f50c0f27c6d5aff3f686bcb48acbd45be115ae2216f36a6a13a7dbbf5cad878b
+"fdir@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "fdir@npm:6.5.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
   languageName: node
   linkType: hard
 
@@ -1219,16 +1135,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "find-up@npm:4.1.0"
-  dependencies:
-    locate-path: "npm:^5.0.0"
-    path-exists: "npm:^4.0.0"
-  checksum: 10c0/0406ee89ebeefa2d507feb07ec366bebd8a6167ae74aa4e34fb4c4abd06cf782a3ce26ae4194d70706f72182841733f00551c209fe575cb00bd92104056e78c1
-  languageName: node
-  linkType: hard
-
 "find-up@npm:^5.0.0":
   version: 5.0.0
   resolution: "find-up@npm:5.0.0"
@@ -1239,14 +1145,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "find-up@npm:7.0.0"
+"find-up@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "find-up@npm:8.0.0"
   dependencies:
-    locate-path: "npm:^7.2.0"
-    path-exists: "npm:^5.0.0"
-    unicorn-magic: "npm:^0.1.0"
-  checksum: 10c0/e6ee3e6154560bc0ab3bc3b7d1348b31513f9bdf49a5dd2e952495427d559fa48cdf33953e85a309a323898b43fa1bfbc8b80c880dfc16068384783034030008
+    locate-path: "npm:^8.0.0"
+    unicorn-magic: "npm:^0.3.0"
+  checksum: 10c0/4c6d2cb92f74bd42ec7344c881a46f6455010d3993f8f55b09bb64298c0a13e11e10200147624db8938590890a15ade69c40f0172698388d0999899f0f2a70a5
   languageName: node
   linkType: hard
 
@@ -1260,26 +1165,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "flat@npm:5.0.2"
-  bin:
-    flat: cli.js
-  checksum: 10c0/f178b13482f0cd80c7fede05f4d10585b1f2fdebf26e12edc138e32d3150c6ea6482b7f12813a1091143bad52bb6d3596bca51a162257a21163c0ff438baa5fe
-  languageName: node
-  linkType: hard
-
 "flatted@npm:^3.2.9":
   version: 3.4.2
   resolution: "flatted@npm:3.4.2"
   checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
-  languageName: node
-  linkType: hard
-
-"function-bind@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "function-bind@npm:1.1.2"
-  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
   languageName: node
   linkType: hard
 
@@ -1298,13 +1187,6 @@ __metadata:
   dependencies:
     is-glob: "npm:^4.0.3"
   checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
-  languageName: node
-  linkType: hard
-
-"glob-to-regexp@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "glob-to-regexp@npm:0.4.1"
-  checksum: 10c0/0486925072d7a916f052842772b61c3e86247f0a80cc0deb9b5a3e8a1a9faad5b04fb6f58986a09f34d3e96cd2a22a24b7e9882fb1cf904c31e9a310de96c429
   languageName: node
   linkType: hard
 
@@ -1340,7 +1222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4":
+"graceful-fs@npm:^4.2.4":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -1354,19 +1236,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "hasown@npm:2.0.2"
-  dependencies:
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.2.0, ignore@npm:^5.3.2":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.5":
+  version: 7.0.6
+  resolution: "ignore@npm:7.0.6"
+  checksum: 10c0/fc01ef1d14efbe003439b60538726351e81483d1b6f55bdbb3a4465c6346d9481afad5b350dfbd604ddd7049618ef9093ff26dc147984aabc303c56ba53ea3b5
   languageName: node
   linkType: hard
 
@@ -1380,38 +1260,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-local@npm:^3.0.2":
-  version: 3.2.0
-  resolution: "import-local@npm:3.2.0"
-  dependencies:
-    pkg-dir: "npm:^4.2.0"
-    resolve-cwd: "npm:^3.0.0"
-  bin:
-    import-local-fixture: fixtures/cli.js
-  checksum: 10c0/94cd6367a672b7e0cb026970c85b76902d2710a64896fa6de93bd5c571dd03b228c5759308959de205083e3b1c61e799f019c9e36ee8e9c523b993e1057f0433
-  languageName: node
-  linkType: hard
-
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
   checksum: 10c0/8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
-  languageName: node
-  linkType: hard
-
-"interpret@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "interpret@npm:3.1.1"
-  checksum: 10c0/6f3c4d0aa6ec1b43a8862375588a249e3c917739895cbe67fe12f0a76260ea632af51e8e2431b50fbcd0145356dc28ca147be08dbe6a523739fd55c0f91dc2a5
-  languageName: node
-  linkType: hard
-
-"is-core-module@npm:^2.16.0":
-  version: 2.16.1
-  resolution: "is-core-module@npm:2.16.1"
-  dependencies:
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
   languageName: node
   linkType: hard
 
@@ -1431,37 +1283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "is-plain-object@npm:2.0.4"
-  dependencies:
-    isobject: "npm:^3.0.1"
-  checksum: 10c0/f050fdd5203d9c81e8c4df1b3ff461c4bc64e8b5ca383bcdde46131361d0a678e80bcf00b5257646f6c636197629644d53bd8e2375aea633de09a82d57e942f4
-  languageName: node
-  linkType: hard
-
 "isexe@npm:^2.0.0":
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: 10c0/228cfa503fadc2c31596ab06ed6aa82c9976eec2bfd83397e7eaf06d0ccf42cd1dfd6743bf9aeb01aebd4156d009994c5f76ea898d2832c1fe342da923ca457d
-  languageName: node
-  linkType: hard
-
-"isobject@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "isobject@npm:3.0.1"
-  checksum: 10c0/03344f5064a82f099a0cd1a8a407f4c0d20b7b8485e8e816c39f249e9416b06c322e8dec5b842b6bb8a06de0af9cb48e7bc1b5352f0fadc2f0abac033db3d4db
-  languageName: node
-  linkType: hard
-
-"jest-worker@npm:^27.4.5":
-  version: 27.5.1
-  resolution: "jest-worker@npm:27.5.1"
-  dependencies:
-    "@types/node": "npm:*"
-    merge-stream: "npm:^2.0.0"
-    supports-color: "npm:^8.0.0"
-  checksum: 10c0/8c4737ffd03887b3c6768e4cc3ca0269c0336c1e4b1b120943958ddb035ed2a0fc6acab6dc99631720a3720af4e708ff84fb45382ad1e83c27946adf3623969b
   languageName: node
   linkType: hard
 
@@ -1490,13 +1315,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
-  languageName: node
-  linkType: hard
-
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -1513,13 +1331,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kind-of@npm:^6.0.2":
-  version: 6.0.3
-  resolution: "kind-of@npm:6.0.3"
-  checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
-  languageName: node
-  linkType: hard
-
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -1527,22 +1338,6 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
-  languageName: node
-  linkType: hard
-
-"loader-runner@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "loader-runner@npm:4.3.1"
-  checksum: 10c0/a523b6329f114e0a98317158e30a7dfce044b731521be5399464010472a93a15ece44757d1eaed1d8845019869c5390218bc1c7c3110f4eeaef5157394486eac
-  languageName: node
-  linkType: hard
-
-"locate-path@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "locate-path@npm:5.0.0"
-  dependencies:
-    p-locate: "npm:^4.1.0"
-  checksum: 10c0/33a1c5247e87e022f9713e6213a744557a3e9ec32c5d0b5efb10aa3a38177615bf90221a5592674857039c1a0fd2063b82f285702d37b792d973e9e72ace6c59
   languageName: node
   linkType: hard
 
@@ -1555,12 +1350,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"locate-path@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "locate-path@npm:7.2.0"
+"locate-path@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "locate-path@npm:8.0.0"
   dependencies:
     p-locate: "npm:^6.0.0"
-  checksum: 10c0/139e8a7fe11cfbd7f20db03923cacfa5db9e14fa14887ea121345597472b4a63c1a42a8a5187defeeff6acf98fd568da7382aa39682d38f0af27433953a97751
+  checksum: 10c0/4c837878b6d1b8557c5d1c624d11d6721d77f4627c14bd84182c85cbb9ec8fc01b5b5f089e21fab17b30fc5ecc14216a3d31f754dfcc5299f1fe9f4c83482fee
   languageName: node
   linkType: hard
 
@@ -1575,27 +1370,6 @@ __metadata:
   version: 11.1.0
   resolution: "lru-cache@npm:11.1.0"
   checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
-  languageName: node
-  linkType: hard
-
-"merge-stream@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "merge-stream@npm:2.0.0"
-  checksum: 10c0/867fdbb30a6d58b011449b8885601ec1690c3e41c759ecd5a9d609094f7aed0096c37823ff4a7190ef0b8f22cc86beb7049196ff68c016e3b3c671d0dac91ce5
-  languageName: node
-  linkType: hard
-
-"mime-db@npm:^1.54.0":
-  version: 1.54.0
-  resolution: "mime-db@npm:1.54.0"
-  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
-  languageName: node
-  linkType: hard
-
-"mimic-fn@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "mimic-fn@npm:3.1.0"
-  checksum: 10c0/a07cdd8ed6490c2dff5b11f889b245d9556b80f5a653a552a651d17cff5a2d156e632d235106c2369f00cccef4071704589574cf3601bc1b1400a1f620dff067
   languageName: node
   linkType: hard
 
@@ -1651,37 +1425,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "multicamsystems-multicamsuite@workspace:."
   dependencies:
-    "@companion-module/base": "npm:~1.12.0"
-    "@companion-module/tools": "npm:^2.7.2"
+    "@companion-module/base": "npm:2.1.2"
+    "@companion-module/tools": "npm:3.0.1"
     "@microsoft/signalr": "npm:^10.0.0"
     "@types/node": "npm:^22.19.18"
     eslint: "npm:^9.39.4"
     prettier: "npm:^3.8.3"
     rimraf: "npm:^6.1.3"
-    typescript: "npm:~5.5.4"
+    typescript: "npm:~6.0.3"
+    typescript-eslint: "npm:^8.56.0"
   languageName: unknown
   linkType: soft
-
-"nanoid@npm:^3.3.11":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
-  languageName: node
-  linkType: hard
 
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
-  languageName: node
-  linkType: hard
-
-"neo-async@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "neo-async@npm:2.6.2"
-  checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
   languageName: node
   linkType: hard
 
@@ -1699,13 +1458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.27":
-  version: 2.0.27
-  resolution: "node-releases@npm:2.0.27"
-  checksum: 10c0/f1e6583b7833ea81880627748d28a3a7ff5703d5409328c216ae57befbced10ce2c991bea86434e8ec39003bd017f70481e2e5f8c1f7e0a7663241f81d6e00e2
-  languageName: node
-  linkType: hard
-
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -1717,22 +1469,6 @@ __metadata:
     type-check: "npm:^0.4.0"
     word-wrap: "npm:^1.2.5"
   checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
-  languageName: node
-  linkType: hard
-
-"p-finally@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-finally@npm:1.0.0"
-  checksum: 10c0/6b8552339a71fe7bd424d01d8451eea92d379a711fc62f6b2fe64cad8a472c7259a236c9a22b4733abca0b5666ad503cb497792a0478c5af31ded793d00937e7
-  languageName: node
-  linkType: hard
-
-"p-limit@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "p-limit@npm:2.3.0"
-  dependencies:
-    p-try: "npm:^2.0.0"
-  checksum: 10c0/8da01ac53efe6a627080fafc127c873da40c18d87b3f5d5492d465bb85ec7207e153948df6b9cbaeb130be70152f874229b8242ee2be84c0794082510af97f12
   languageName: node
   linkType: hard
 
@@ -1754,15 +1490,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-locate@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "p-locate@npm:4.1.0"
-  dependencies:
-    p-limit: "npm:^2.2.0"
-  checksum: 10c0/1b476ad69ad7f6059744f343b26d51ce091508935c1dbb80c4e0a2f397ffce0ca3a1f9f5cd3c7ce19d7929a09719d5c65fe70d8ee289c3f267cd36f2881813e9
-  languageName: node
-  linkType: hard
-
 "p-locate@npm:^5.0.0":
   version: 5.0.0
   resolution: "p-locate@npm:5.0.0"
@@ -1778,39 +1505,6 @@ __metadata:
   dependencies:
     p-limit: "npm:^4.0.0"
   checksum: 10c0/d72fa2f41adce59c198270aa4d3c832536c87a1806e0f69dffb7c1a7ca998fb053915ca833d90f166a8c082d3859eabfed95f01698a3214c20df6bb8de046312
-  languageName: node
-  linkType: hard
-
-"p-queue@npm:^6.6.2":
-  version: 6.6.2
-  resolution: "p-queue@npm:6.6.2"
-  dependencies:
-    eventemitter3: "npm:^4.0.4"
-    p-timeout: "npm:^3.2.0"
-  checksum: 10c0/5739ecf5806bbeadf8e463793d5e3004d08bb3f6177bd1a44a005da8fd81bb90f80e4633e1fb6f1dfd35ee663a5c0229abe26aebb36f547ad5a858347c7b0d3e
-  languageName: node
-  linkType: hard
-
-"p-timeout@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "p-timeout@npm:3.2.0"
-  dependencies:
-    p-finally: "npm:^1.0.0"
-  checksum: 10c0/524b393711a6ba8e1d48137c5924749f29c93d70b671e6db761afa784726572ca06149c715632da8f70c090073afb2af1c05730303f915604fd38ee207b70a61
-  languageName: node
-  linkType: hard
-
-"p-timeout@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "p-timeout@npm:4.1.0"
-  checksum: 10c0/25aaf13ae9ebfff4ab45591f6647f3bee1ecede073c367175fb0157c27efb170cfb51259a4d2e9118d2ca595453bc885f086ad0ca7476d1c26cee3d13a7c9f6d
-  languageName: node
-  linkType: hard
-
-"p-try@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "p-try@npm:2.2.0"
-  checksum: 10c0/c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
   languageName: node
   linkType: hard
 
@@ -1830,15 +1524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-author@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "parse-author@npm:2.0.0"
-  dependencies:
-    author-regex: "npm:^1.0.0"
-  checksum: 10c0/8b4c19523588a4271c89f64e8167be7c80b4765059c865d38a996c37d080c7e5123e3e2d07d47290891628ad27f4dfb692e3b61156c52fcc0af6cdce3ed57afd
-  languageName: node
-  linkType: hard
-
 "path-exists@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
@@ -1846,24 +1531,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-exists@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "path-exists@npm:5.0.0"
-  checksum: 10c0/b170f3060b31604cde93eefdb7392b89d832dfbc1bed717c9718cbe0f230c1669b7e75f87e19901da2250b84d092989a0f9e44d2ef41deb09aa3ad28e691a40a
-  languageName: node
-  linkType: hard
-
 "path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
-  languageName: node
-  linkType: hard
-
-"path-parse@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "path-parse@npm:1.0.7"
-  checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
   languageName: node
   linkType: hard
 
@@ -1877,26 +1548,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "picocolors@npm:1.1.1"
-  checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.2":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
-  languageName: node
-  linkType: hard
-
-"pkg-dir@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "pkg-dir@npm:4.2.0"
-  dependencies:
-    find-up: "npm:^4.0.0"
-  checksum: 10c0/c56bda7769e04907a88423feb320babaed0711af8c436ce3e56763ab1021ba107c7b0cafb11cde7529f669cfc22bffcaebffb573645cbd63842ea9fb17cd7728
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.4":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
   languageName: node
   linkType: hard
 
@@ -1948,35 +1603,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rechoir@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "rechoir@npm:0.8.0"
-  dependencies:
-    resolve: "npm:^1.20.0"
-  checksum: 10c0/1a30074124a22abbd5d44d802dac26407fa72a0a95f162aa5504ba8246bc5452f8b1a027b154d9bdbabcd8764920ff9333d934c46a8f17479c8912e92332f3ff
-  languageName: node
-  linkType: hard
-
-"require-from-string@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "require-from-string@npm:2.0.2"
-  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
-  languageName: node
-  linkType: hard
-
 "requires-port@npm:^1.0.0":
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: 10c0/b2bfdd09db16c082c4326e573a82c0771daaf7b53b9ce8ad60ea46aa6e30aaf475fe9b164800b89f93b748d2c234d8abff945d2551ba47bf5698e04cd7713267
-  languageName: node
-  linkType: hard
-
-"resolve-cwd@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-cwd@npm:3.0.0"
-  dependencies:
-    resolve-from: "npm:^5.0.0"
-  checksum: 10c0/e608a3ebd15356264653c32d7ecbc8fd702f94c6703ea4ac2fb81d9c359180cba0ae2e6b71faa446631ed6145454d5a56b227efc33a2d40638ac13f8beb20ee4
   languageName: node
   linkType: hard
 
@@ -1987,43 +1617,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-from@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "resolve-from@npm:5.0.0"
-  checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
-  languageName: node
-  linkType: hard
-
 "resolve-pkg-maps@npm:^1.0.0":
   version: 1.0.0
   resolution: "resolve-pkg-maps@npm:1.0.0"
   checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.20.0":
-  version: 1.22.10
-  resolution: "resolve@npm:1.22.10"
-  dependencies:
-    is-core-module: "npm:^2.16.0"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/8967e1f4e2cc40f79b7e080b4582b9a8c5ee36ffb46041dccb20e6461161adf69f843b43067b4a375de926a2cd669157e29a29578191def399dd5ef89a1b5203
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
-  version: 1.22.10
-  resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
-  dependencies:
-    is-core-module: "npm:^2.16.0"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/52a4e505bbfc7925ac8f4cd91fd8c4e096b6a89728b9f46861d3b405ac9a1ccf4dcbf8befb4e89a2e11370dacd0160918163885cbc669369590f2f31f4c58939
   languageName: node
   linkType: hard
 
@@ -2039,18 +1636,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^4.3.0, schema-utils@npm:^4.3.3":
-  version: 4.3.3
-  resolution: "schema-utils@npm:4.3.3"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.9"
-    ajv: "npm:^8.9.0"
-    ajv-formats: "npm:^2.1.1"
-    ajv-keywords: "npm:^5.1.0"
-  checksum: 10c0/1c8d2c480a026d7c02ab2ecbe5919133a096d6a721a3f201fa50663e4f30f6d6ba020dfddd93cb828b66b922e76b342e103edd19a62c95c8f60e9079cc403202
-  languageName: node
-  linkType: hard
-
 "semver@npm:^7.5.4, semver@npm:^7.6.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
@@ -2060,12 +1645,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "semver@npm:7.7.4"
+"semver@npm:^7.7.3, semver@npm:^7.7.4":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -2073,15 +1658,6 @@ __metadata:
   version: 2.7.2
   resolution: "set-cookie-parser@npm:2.7.2"
   checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
-  languageName: node
-  linkType: hard
-
-"shallow-clone@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "shallow-clone@npm:3.0.1"
-  dependencies:
-    kind-of: "npm:^6.0.2"
-  checksum: 10c0/7bab09613a1b9f480c85a9823aebec533015579fa055ba6634aa56ba1f984380670eaf33b8217502931872aa1401c9fcadaa15f9f604d631536df475b05bcf1e
   languageName: node
   linkType: hard
 
@@ -2101,23 +1677,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:~0.5.20":
-  version: 0.5.21
-  resolution: "source-map-support@npm:0.5.21"
-  dependencies:
-    buffer-from: "npm:^1.0.0"
-    source-map: "npm:^0.6.0"
-  checksum: 10c0/9ee09942f415e0f721d6daad3917ec1516af746a8120bba7bb56278707a37f1eb8642bde456e98454b8a885023af81a16e646869975f06afc1a711fb90484e7d
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.6.0":
-  version: 0.6.1
-  resolution: "source-map@npm:0.6.1"
-  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -2134,90 +1693,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
+"synckit@npm:^0.11.13":
+  version: 0.11.13
+  resolution: "synckit@npm:0.11.13"
   dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
+    "@pkgr/core": "npm:^0.3.6"
+  checksum: 10c0/5a6c19f4f79045aaa7994106401bff6dbe7cca23a6d0a0723ff14eb8b1bebeb4a71729118f6914905598e304ea2fa13509885e11ba07d92e7cb68a06740cb328
   languageName: node
   linkType: hard
 
-"supports-preserve-symlinks-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
-  checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
-  languageName: node
-  linkType: hard
-
-"synckit@npm:^0.11.12":
-  version: 0.11.12
-  resolution: "synckit@npm:0.11.12"
-  dependencies:
-    "@pkgr/core": "npm:^0.2.9"
-  checksum: 10c0/cc4d446806688ae0d728ae7bb3f53176d065cf9536647fb85bdd721dcefbd7bf94874df6799ff61580f2b03a392659219b778a9254ad499f9a1f56c34787c235
-  languageName: node
-  linkType: hard
-
-"tapable@npm:^2.2.0, tapable@npm:^2.3.0":
+"tapable@npm:^2.2.0":
   version: 2.3.0
   resolution: "tapable@npm:2.3.0"
   checksum: 10c0/cb9d67cc2c6a74dedc812ef3085d9d681edd2c1fa18e4aef57a3c0605fdbe44e6b8ea00bd9ef21bc74dd45314e39d31227aa031ebf2f5e38164df514136f2681
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "tapable@npm:2.3.3"
-  checksum: 10c0/47992e861053f861154e92fb4a98ac4ab47b6463717e60792dd1e8c755da0c4964cd8bb68c308a9066d6da89000b6310457b4d5d985c30de4ccc29066068cc17
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.9":
-  version: 7.5.20
-  resolution: "tar@npm:7.5.20"
+"tar@npm:^7.5.13":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.17":
-  version: 5.5.0
-  resolution: "terser-webpack-plugin@npm:5.5.0"
+"tinyglobby@npm:^0.2.15":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jest-worker: "npm:^27.4.5"
-    schema-utils: "npm:^4.3.0"
-    terser: "npm:^5.31.1"
-  peerDependencies:
-    webpack: ^5.1.0
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    esbuild:
-      optional: true
-    uglify-js:
-      optional: true
-  checksum: 10c0/ea2277cc6c80981fd8ce170016b1cd92d33cdf89d50e81ad387218dd46db55b8d69c8f736a35d7deb238962dbe003dd084f0a2494cbbd55f46a9c9d3e90e583a
-  languageName: node
-  linkType: hard
-
-"terser@npm:^5.31.1":
-  version: 5.43.1
-  resolution: "terser@npm:5.43.1"
-  dependencies:
-    "@jridgewell/source-map": "npm:^0.3.3"
-    acorn: "npm:^8.14.0"
-    commander: "npm:^2.20.0"
-    source-map-support: "npm:~0.5.20"
-  bin:
-    terser: bin/terser
-  checksum: 10c0/9cd3fa09ea6bcb79eb71995216b8bef0651b18c5c3877535fc699a77e1ab43b140a4da5811ac9baeb654fa9ec939b17324092f0f0bdb19c402e101e3db946986
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
   languageName: node
   linkType: hard
 
@@ -2240,6 +1751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "ts-api-utils@npm:2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
+  languageName: node
+  linkType: hard
+
 "ts-declaration-location@npm:^1.0.6":
   version: 1.0.7
   resolution: "ts-declaration-location@npm:1.0.7"
@@ -2248,13 +1768,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.0.0"
   checksum: 10c0/b579b7630907052cc174b051dffdb169424824d887d8fb5abdc61e7ab0eede348c2b71c998727b9e4b314c0436f5003a15bb7eedb1c851afe96e12499f159630
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.8.1":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -2267,23 +1780,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.5.4":
-  version: 5.5.4
-  resolution: "typescript@npm:5.5.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+"typescript-eslint@npm:^8.56.0":
+  version: 8.65.0
+  resolution: "typescript-eslint@npm:8.65.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.65.0"
+    "@typescript-eslint/parser": "npm:8.65.0"
+    "@typescript-eslint/typescript-estree": "npm:8.65.0"
+    "@typescript-eslint/utils": "npm:8.65.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/d1f5eede08c6d0d500aa605a1de2a4e721c00e8f56f632581e082aac6d1d2b9d365ce692cf5e0e212ea78271a032c8785e0fc58aee276c7930f92fff6a3358c8
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.5.4#optional!builtin<compat/typescript>":
-  version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 
@@ -2294,17 +1822,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.8.0":
-  version: 7.8.0
-  resolution: "undici-types@npm:7.8.0"
-  checksum: 10c0/9d9d246d1dc32f318d46116efe3cfca5a72d4f16828febc1918d94e58f6ffcf39c158aa28bf5b4fc52f410446bc7858f35151367bd7a49f21746cab6497b709b
-  languageName: node
-  linkType: hard
-
-"unicorn-magic@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "unicorn-magic@npm:0.1.0"
-  checksum: 10c0/e4ed0de05b0a05e735c7d8a2930881e5efcfc3ec897204d5d33e7e6247f4c31eac92e383a15d9a6bccb7319b4271ee4bea946e211bf14951fec6ff2cbbb66a92
+"unicorn-magic@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "unicorn-magic@npm:0.3.0"
+  checksum: 10c0/0a32a997d6c15f1c2a077a15b1c4ca6f268d574cf5b8975e778bb98e6f8db4ef4e86dfcae4e158cd4c7e38fb4dd383b93b13eefddc7f178dea13d3ac8a603271
   languageName: node
   linkType: hard
 
@@ -2312,20 +1833,6 @@ __metadata:
   version: 0.2.0
   resolution: "universalify@npm:0.2.0"
   checksum: 10c0/cedbe4d4ca3967edf24c0800cfc161c5a15e240dac28e3ce575c689abc11f2c81ccc6532c8752af3b40f9120fb5e454abecd359e164f4f6aa44c29cd37e194fe
-  languageName: node
-  linkType: hard
-
-"update-browserslist-db@npm:^1.2.0":
-  version: 1.2.3
-  resolution: "update-browserslist-db@npm:1.2.3"
-  dependencies:
-    escalade: "npm:^3.2.0"
-    picocolors: "npm:^1.1.1"
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 10c0/13a00355ea822388f68af57410ce3255941d5fb9b7c49342c4709a07c9f230bbef7f7499ae0ca7e0de532e79a82cc0c4edbd125f1a323a1845bf914efddf8bec
   languageName: node
   linkType: hard
 
@@ -2348,105 +1855,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "watchpack@npm:2.5.1"
-  dependencies:
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.1.2"
-  checksum: 10c0/dffbb483d1f61be90dc570630a1eb308581e2227d507d783b1d94a57ac7b705ecd9a1a4b73d73c15eab596d39874e5276a3d9cb88bbb698bafc3f8d08c34cf17
-  languageName: node
-  linkType: hard
-
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
   checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
-  languageName: node
-  linkType: hard
-
-"webpack-cli@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "webpack-cli@npm:6.0.1"
-  dependencies:
-    "@discoveryjs/json-ext": "npm:^0.6.1"
-    "@webpack-cli/configtest": "npm:^3.0.1"
-    "@webpack-cli/info": "npm:^3.0.1"
-    "@webpack-cli/serve": "npm:^3.0.1"
-    colorette: "npm:^2.0.14"
-    commander: "npm:^12.1.0"
-    cross-spawn: "npm:^7.0.3"
-    envinfo: "npm:^7.14.0"
-    fastest-levenshtein: "npm:^1.0.12"
-    import-local: "npm:^3.0.2"
-    interpret: "npm:^3.1.1"
-    rechoir: "npm:^0.8.0"
-    webpack-merge: "npm:^6.0.1"
-  peerDependencies:
-    webpack: ^5.82.0
-  peerDependenciesMeta:
-    webpack-bundle-analyzer:
-      optional: true
-    webpack-dev-server:
-      optional: true
-  bin:
-    webpack-cli: ./bin/cli.js
-  checksum: 10c0/2aaca78e277427f03f528602abd707d224696048fb46286ea636c7975592409c4381ca94d68bbbb3900f195ca97f256e619583e8feb34a80da531461323bf3e2
-  languageName: node
-  linkType: hard
-
-"webpack-merge@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "webpack-merge@npm:6.0.1"
-  dependencies:
-    clone-deep: "npm:^4.0.1"
-    flat: "npm:^5.0.2"
-    wildcard: "npm:^2.0.1"
-  checksum: 10c0/bf1429567858b353641801b8a2696ca0aac270fc8c55d4de8a7b586fe07d27fdcfc83099a98ab47e6162383db8dd63bb8cc25b1beb2ec82150422eec843b0dc0
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.3.4":
-  version: 3.4.0
-  resolution: "webpack-sources@npm:3.4.0"
-  checksum: 10c0/a37214f85e9b81897b46b27063f12ddb80adeef3249d10502f7e8279357d1fc812d40429df7a726e26ac21a6f5e22448e1d00d53aa15c1b2827a5929ba261969
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.105.2":
-  version: 5.106.2
-  resolution: "webpack@npm:5.106.2"
-  dependencies:
-    "@types/eslint-scope": "npm:^3.7.7"
-    "@types/estree": "npm:^1.0.8"
-    "@types/json-schema": "npm:^7.0.15"
-    "@webassemblyjs/ast": "npm:^1.14.1"
-    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.16.0"
-    acorn-import-phases: "npm:^1.0.3"
-    browserslist: "npm:^4.28.1"
-    chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.20.0"
-    es-module-lexer: "npm:^2.0.0"
-    eslint-scope: "npm:5.1.1"
-    events: "npm:^3.2.0"
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.2.11"
-    loader-runner: "npm:^4.3.1"
-    mime-db: "npm:^1.54.0"
-    neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^4.3.3"
-    tapable: "npm:^2.3.0"
-    terser-webpack-plugin: "npm:^5.3.17"
-    watchpack: "npm:^2.5.1"
-    webpack-sources: "npm:^3.3.4"
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 10c0/933293ae94b7f3405147aebd824d978696693a7fbd85cfbf4d05b517329c93f69e634400ad70a27f4ba4148e14e2fd502e335cd8d30d75282091ab3c72a1ac01
   languageName: node
   linkType: hard
 
@@ -2468,13 +1880,6 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 10c0/66522872a768b60c2a65a57e8ad184e5372f5b6a9ca6d5f033d4b0dc98aff63995655a7503b9c0a2598936f532120e81dd8cc155e2e92ed662a2b9377cc4374f
-  languageName: node
-  linkType: hard
-
-"wildcard@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "wildcard@npm:2.0.1"
-  checksum: 10c0/08f70cd97dd9a20aea280847a1fe8148e17cae7d231640e41eb26d2388697cbe65b67fd9e68715251c39b080c5ae4f76d71a9a69fa101d897273efdfb1b58bf7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This pull request updates the module to support MultiCam Suite 2.1 and Companion Base 2.1.

It significantly expands the available controls, improves API and SignalR connection reliability, and adds ready-to-use presets for the main MultiCam Suite workflows.

## Main changes

- Update the module version to `2.1.1`
- Migrate to `@companion-module/base` 2.1.2 and the latest Companion tooling
- Add and expand actions for:
  - Application
  - Audio
  - Camera
  - Composer
  - Conf
  - Insitu
  - Medialist
  - Pilot
  - Publisher
  - Radio
  - Recording
  - Scenes
  - Streaming
  - Studio
  - Titler
  - Video
- Add new feedbacks and variables for polled and real-time states
- Add dynamic presets organized by feature
- Add preset feedback colors and improve recording button visibility
- Improve polling and automatic refresh of API resources
- Improve SignalR synchronization, health checks, reconnection handling, and connection status reporting
- Add API request health monitoring and recovery logic
- Store the API key as a Companion secret
- Add configuration migration support for existing installations
- Update the module manifest and documentation
- Remove deprecated API groups from the exposed controls
